### PR TITLE
Improve parser creating quasiloglikelihood function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 [![build](https://github.com/cbg-ethz/covvfit/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/cbg-ethz/covvfit/actions/workflows/test.yml)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/charliermarsh/ruff)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![PyPI Latest Release](https://img.shields.io/pypi/v/covvfit.svg)](https://pypi.org/project/covvfit/)
 
 
 # covvfit
+
 Fitness estimates of SARS-CoV-2 variants.
+
+**Note: this package is in currently in an alpha stage. The API is expected to be refined and the documentation is being currently developed.** 
+
 
   - **Documentation:** [https://cbg-ethz.github.io/covvfit](https://cbg-ethz.github.io/covvfit)
   - **Source code:** [https://github.com/cbg-ethz/covvfit](https://github.com/cbg-ethz/covvfit)

--- a/src/covvfit/_padding.py
+++ b/src/covvfit/_padding.py
@@ -1,0 +1,74 @@
+from typing import Sequence, TypeVar
+
+import jax
+import jax.numpy as jnp
+
+T = TypeVar("T")
+
+
+def _is_scalar(value) -> bool:
+    return not hasattr(value, "__len__")
+
+
+def create_padded_array(
+    values: T | Sequence[T] | Sequence[jax.Array] | Sequence[Sequence[T]],
+    lengths: list[int],
+    padding_length: int,
+    padding_value: T,
+    _out_dtype=float,
+) -> jax.Array:
+    """Parsing utility, which pads `values`
+    into a two-dimensional array describing multiple time series.
+
+    Args:
+        values: provided values for each group.
+            It can be the following a scalar value
+            (constant for all time series) or a sequence of values
+            describing the observations of each time series.
+            If it is a sequence, then each entry can be either
+            a single value (constant for the time series) or
+            an array specifying values for all the time points in the
+            particular time series
+        lengths: lengths of the timeseries, one per time series
+        padding_length: padding length, must be larger than all entries
+            in `lengths`
+
+    Returns:
+        JAX array of shape (n_timeseries, padding_length)
+    """
+    n_cities = len(lengths)
+    if n_cities < 1:
+        raise ValueError("There has to be at least one city.")
+    if max(lengths) > padding_length:
+        raise ValueError(
+            f"Maximum length is {max(lengths)}, which is greater than the padding {padding_length}."
+        )
+
+    out_array = jnp.full(
+        shape=(n_cities, padding_length), fill_value=padding_value, dtype=_out_dtype
+    )
+
+    # First case: `values` argument is a single number (not an iterable)
+    if _is_scalar(values):
+        for i, length in enumerate(lengths):
+            out_array = out_array.at[i, :length].set(values)
+        return out_array
+
+    # Second case: `values` argument is not a scalar, but rather an iterable:
+    if len(values) != n_cities:
+        raise ValueError(
+            f"Provided list has length {len(values)} rather than {n_cities}."
+        )
+
+    for i, (value, exp_len) in enumerate(zip(values, lengths)):
+        if _is_scalar(value):  # For this city we have constant value provided
+            out_array = out_array.at[i, :exp_len].set(value)
+        else:  # We have a vector of values provided
+            if len(value) != exp_len:
+                raise ValueError(
+                    f"For {i}th component the provided array has length {len(value)} rather than {exp_len}."
+                )
+            vals = jnp.asarray(value, dtype=out_array.dtype)
+            out_array = out_array.at[i, :exp_len].set(vals)
+
+    return out_array

--- a/src/covvfit/_quasimultinomial.py
+++ b/src/covvfit/_quasimultinomial.py
@@ -438,11 +438,16 @@ _OverDispersionType = (
 )
 
 
+def _is_scalar(value) -> bool:
+    return not hasattr(value, "__len__")
+
+
 def _create_padded_array(
     values: _OverDispersionType,
     expected_lengths: list[int],
     padding_length: int,
     padding_value: float,
+    _out_dtype=float,
 ) -> Float[Array, "n_cities padding_length"]:
     n_cities = len(expected_lengths)
     if n_cities < 1:
@@ -452,24 +457,34 @@ def _create_padded_array(
             f"Maximum length is {max(expected_lengths)}, which is greater than the padding {padding_length}."
         )
 
-    out_array = jnp.full(shape=(n_cities, padding_length), fill_value=padding_value)
+    out_array = jnp.full(
+        shape=(n_cities, padding_length), fill_value=padding_value, dtype=_out_dtype
+    )
 
     # First case: `values` argument is a single number (not an iterable)
-    if not hasattr(values, "__len__"):
+    if _is_scalar(values):
         for i, length in enumerate(expected_lengths):
             out_array = out_array.at[i, :length].set(values)
         return out_array
 
-    # Second case: `values` argument is an iterable
+    # Second case: `values` argument is not a scalar, but rather an iterable:
     if len(values) != n_cities:
         raise ValueError(
             f"Provided list has length {len(values)} rather than {n_cities}."
         )
 
     for i, (value, exp_len) in enumerate(zip(values, expected_lengths)):
-        pass
+        if _is_scalar(value):  # For this city we have constant value provided
+            out_array = out_array.at[i, :exp_len].set(value)
+        else:  # We have a vector of values provided
+            if len(value) != exp_len:
+                raise ValueError(
+                    f"For {i}th component the provided array has length {len(value)} rather than {exp_len}."
+                )
+            vals = jnp.asarray(value, dtype=out_array.dtype)
+            out_array = out_array.at[i, :exp_len].set(vals)
 
-    raise NotImplementedError
+    return out_array
 
 
 def _validate_and_pad(

--- a/src/covvfit/_quasimultinomial.py
+++ b/src/covvfit/_quasimultinomial.py
@@ -611,8 +611,8 @@ def _generate_quasiloglikelihood_function(
 def construct_model(
     ys: list[jax.Array],
     ts: list[jax.Array],
-    ns: Float[Array, " cities"] | list[float] | float = 1.0,
-    overdispersion: Float[Array, " cities"] | list[float] | float = 1.0,
+    ns: _OverDispersionType,
+    overdispersion: _OverDispersionType,
     sigma_growth: float = 10.0,
     sigma_offset: float = 1000.0,
 ) -> Callable:
@@ -678,8 +678,8 @@ def construct_model(
 def construct_total_loss(
     ys: list[jax.Array],
     ts: list[jax.Array],
-    ns: list[float] | float = 1.0,
-    overdispersion: list[float] | float = 1.0,
+    ns: _OverDispersionType,
+    overdispersion: _OverDispersionType,
     accept_theta: bool = True,
     average_loss: bool = False,
 ) -> Callable[[_ThetaType], _Float] | _RelativeGrowthsAndOffsetsFunction:

--- a/src/covvfit/_quasimultinomial.py
+++ b/src/covvfit/_quasimultinomial.py
@@ -11,6 +11,8 @@ import numpyro.distributions as distrib
 from jaxtyping import Array, Bool, Float
 from scipy import optimize
 
+from covvfit._padding import create_padded_array
+
 
 def calculate_linear(
     ts: Float[Array, " *batch"],
@@ -438,55 +440,6 @@ _OverDispersionType = (
 )
 
 
-def _is_scalar(value) -> bool:
-    return not hasattr(value, "__len__")
-
-
-def _create_padded_array(
-    values: _OverDispersionType,
-    expected_lengths: list[int],
-    padding_length: int,
-    padding_value: float,
-    _out_dtype=float,
-) -> Float[Array, "n_cities padding_length"]:
-    n_cities = len(expected_lengths)
-    if n_cities < 1:
-        raise ValueError("There has to be at least one city.")
-    if max(expected_lengths) > padding_length:
-        raise ValueError(
-            f"Maximum length is {max(expected_lengths)}, which is greater than the padding {padding_length}."
-        )
-
-    out_array = jnp.full(
-        shape=(n_cities, padding_length), fill_value=padding_value, dtype=_out_dtype
-    )
-
-    # First case: `values` argument is a single number (not an iterable)
-    if _is_scalar(values):
-        for i, length in enumerate(expected_lengths):
-            out_array = out_array.at[i, :length].set(values)
-        return out_array
-
-    # Second case: `values` argument is not a scalar, but rather an iterable:
-    if len(values) != n_cities:
-        raise ValueError(
-            f"Provided list has length {len(values)} rather than {n_cities}."
-        )
-
-    for i, (value, exp_len) in enumerate(zip(values, expected_lengths)):
-        if _is_scalar(value):  # For this city we have constant value provided
-            out_array = out_array.at[i, :exp_len].set(value)
-        else:  # We have a vector of values provided
-            if len(value) != exp_len:
-                raise ValueError(
-                    f"For {i}th component the provided array has length {len(value)} rather than {exp_len}."
-                )
-            vals = jnp.asarray(value, dtype=out_array.dtype)
-            out_array = out_array.at[i, :exp_len].set(vals)
-
-    return out_array
-
-
 def _validate_and_pad(
     ys: list[jax.Array],
     ts: list[jax.Array],
@@ -528,29 +481,29 @@ def _validate_and_pad(
         max_timepoints = max(max_timepoints, t.shape[0])
 
     _lengths = [t.shape[0] for t in ts]
-    out_n = _create_padded_array(
+    out_n = create_padded_array(
         values=ns_quasimul,
-        expected_lengths=_lengths,
+        lengths=_lengths,
         padding_length=max_timepoints,
         padding_value=0.0,
     )
-    out_overdispersion = _create_padded_array(
+    out_overdispersion = create_padded_array(
         values=overdispersion,
-        expected_lengths=_lengths,
+        lengths=_lengths,
         padding_length=max_timepoints,
         padding_value=1.0,  # Use 1.0 as we divide by it and want to avoid NaNs
     )
 
     # Now create the arrays representing the data
-    out_ts = _create_padded_array(
+    out_ts = create_padded_array(
         values=ts,
-        expected_lengths=_lengths,
+        lengths=_lengths,
         padding_length=max_timepoints,
         padding_value=0.0,
     )
-    out_mask = _create_padded_array(
+    out_mask = create_padded_array(
         values=1,
-        expected_lengths=_lengths,
+        lengths=_lengths,
         padding_length=max_timepoints,
         padding_value=0,
         _out_dtype=bool,

--- a/src/covvfit/_quasimultinomial.py
+++ b/src/covvfit/_quasimultinomial.py
@@ -634,16 +634,18 @@ def construct_model(
     """Builds a NumPyro model suitable for sampling from the quasiposterior.
 
     Args:
-        ys: list of variant proportions for each city.
+        ys: list of variant proportions array for each city.
             The ith entry should be an array
             of shape (n_timepoints[i], n_variants)
-        ts: list of timepoints. The ith entry should be an array
+        ts: list of timepoint arrays. The ith entry should be an array
             of shape (n_timepoints[i],)
             Note: `ts` should be appropriately normalized
-        ns: controls the overdispersion of each city by means of
-            quasimultinomial sample size
+        ns: controls the quasimultinomial sample size of each city. It can be:
+              - a single float (sample size is constant across all cities and timepoints)
+              - a sequence of floats, describing one sample size for each city
+              - a list of arrays, with the `i`th entry having length `n_timepoints[i]`
         overdispersion: controls the overdispersion factor as in the
-            quasilikelihood approach
+            quasilikelihood approach. The shape restrictions are the same as in `ns`.
         sigma_growth: controls the standard deviation of the prior
             on the relative growths
         sigma_offset: controls the standard deviation of the prior
@@ -707,10 +709,12 @@ def construct_total_loss(
         ts: list of timepoints. The ith entry should be an array
             of shape (n_timepoints[i],)
             Note: `ts` should be appropriately normalized
-        ns: controls the overdispersion of each city by means of
-            quasimultinomial sample size
+        ns: controls the quasimultinomial sample size of each city. It can be:
+              - a single float (sample size is constant across all cities and timepoints)
+              - a sequence of floats, describing one sample size for each city
+              - a list of arrays, with the `i`th entry having length `n_timepoints[i]`
         overdispersion: controls the overdispersion factor as in the
-            quasilikelihood approach
+            quasilikelihood approach. The shape restrictions are the same as in `ns`.
         accept_theta: whether the returned loss function should accept the
             `theta` vector (suitable for optimization)
             or should be parameterized by the relative growths

--- a/src/covvfit/_quasimultinomial.py
+++ b/src/covvfit/_quasimultinomial.py
@@ -542,18 +542,27 @@ def _validate_and_pad(
     )
 
     # Now create the arrays representing the data
-    out_ts = jnp.zeros((n_cities, max_timepoints))  # Pad with zeros
-    out_mask = jnp.zeros((n_cities, max_timepoints))  # Pad with zeros
+    out_ts = _create_padded_array(
+        values=ts,
+        expected_lengths=_lengths,
+        padding_length=max_timepoints,
+        padding_value=0.0,
+    )
+    out_mask = _create_padded_array(
+        values=1.0,
+        expected_lengths=_lengths,
+        padding_length=max_timepoints,
+        padding_value=0.0,
+    )
+
+    # Create the array with variant proportions, padded with constant vectors
     out_ys = jnp.full(
         shape=(n_cities, max_timepoints, n_variants), fill_value=1.0 / n_variants
-    )  # Pad with constant vectors
+    )
 
-    for i, (t, y) in enumerate(zip(ts, ys)):
-        n_timepoints = t.shape[0]
-
-        out_ts = out_ts.at[i, :n_timepoints].set(t)
+    for i, y in enumerate(ys):
+        n_timepoints = y.shape[0]
         out_ys = out_ys.at[i, :n_timepoints, :].set(y)
-        out_mask = out_mask.at[i, :n_timepoints].set(1)
 
     return _ProblemData(
         n_cities=n_cities,

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -1,0 +1,264 @@
+import jax.numpy as jnp
+import numpy.testing as npt
+import pytest
+from covvfit._padding import create_padded_array
+from jax import random
+
+
+def test_scalar_value():
+    """Test with a single scalar value."""
+    values = 3.14
+    lengths = [2, 3]
+    padding_length = 4
+    padding_value = 0.0
+
+    expected = jnp.array([[3.14, 3.14, 0.0, 0.0], [3.14, 3.14, 3.14, 0.0]])
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+    npt.assert_array_equal(result, expected)
+
+
+def test_list_of_scalars():
+    """Test with a list of scalar values."""
+    values = [1.0, 2.0, 3.0]
+    lengths = [1, 2, 3]
+    padding_length = 4
+    padding_value = -1.0
+
+    expected = jnp.array(
+        [[1.0, -1.0, -1.0, -1.0], [2.0, 2.0, -1.0, -1.0], [3.0, 3.0, 3.0, -1.0]]
+    )
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+    npt.assert_array_equal(result, expected)
+
+
+def test_list_of_arrays():
+    """Test with a list of JAX arrays."""
+    values = [
+        jnp.array([1.1, 1.2]),
+        jnp.array([2.1, 2.2, 2.3]),
+        jnp.array([3.1, 3.2, 3.3, 3.4]),
+    ]
+    lengths = [2, 3, 4]
+    padding_length = 5
+    padding_value = 0.0
+
+    expected = jnp.array(
+        [
+            [1.1, 1.2, 0.0, 0.0, 0.0],
+            [2.1, 2.2, 2.3, 0.0, 0.0],
+            [3.1, 3.2, 3.3, 3.4, 0.0],
+        ]
+    )
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+    npt.assert_array_equal(result, expected)
+
+
+def test_nested_list_of_floats():
+    """Test with a nested list of floats."""
+    values = [[1.0, 1.1], [2.0, 2.1, 2.2], [3.0, 3.1, 3.2, 3.3]]
+    lengths = [2, 3, 4]
+    padding_length = 5
+    padding_value = -5.0
+
+    expected = jnp.array(
+        [
+            [1.0, 1.1, -5.0, -5.0, -5.0],
+            [2.0, 2.1, 2.2, -5.0, -5.0],
+            [3.0, 3.1, 3.2, 3.3, -5.0],
+        ]
+    )
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+    npt.assert_array_equal(result, expected)
+
+
+def test_empty_cities():
+    """Test with zero cities, expecting a ValueError."""
+    values = []
+    lengths = []
+    padding_length = 3
+    padding_value = 0.0
+
+    with pytest.raises(ValueError, match="There has to be at least one city."):
+        create_padded_array(values, lengths, padding_length, padding_value)
+
+
+def test_max_length_exceeds_padding():
+    """Test when the maximum expected length exceeds the padding length."""
+    values = [1.0, 2.0, 3.0]
+    lengths = [2, 5, 3]
+    padding_length = 4
+    padding_value = 0.0
+
+    with pytest.raises(
+        ValueError, match="Maximum length is 5, which is greater than the padding 4."
+    ):
+        create_padded_array(values, lengths, padding_length, padding_value)
+
+
+def test_values_length_mismatch():
+    """Test when the length of values does not match the number of cities."""
+    values = [1.0, 2.0]  # Only 2 values
+    lengths = [1, 2, 3]
+    padding_length = 3
+    padding_value = 0.0
+
+    with pytest.raises(ValueError, match="Provided list has length 2 rather than 3."):
+        create_padded_array(values, lengths, padding_length, padding_value)
+
+
+def test_value_length_mismatch_per_city():
+    """Test when a city's value length does not match its expected length."""
+    values = [[1.0, 1.1], [2.0], [3.0, 3.1, 3.2]]  # Expected length is 3
+    lengths = [2, 3, 3]
+    padding_length = 4
+    padding_value = 0.0
+
+    with pytest.raises(
+        ValueError,
+        match="For 1th component the provided array has length 1 rather than 3.",
+    ):
+        create_padded_array(values, lengths, padding_length, padding_value)
+
+
+def test_different_out_dtype():
+    """Test with a different output data type."""
+    values = [1, 2, 3]
+    lengths = [1, 2, 3]
+    padding_length = 3
+    padding_value = 0
+    _out_dtype = jnp.int32
+
+    expected = jnp.array([[1, 0, 0], [2, 2, 0], [3, 3, 3]], dtype=jnp.int32)
+
+    result = create_padded_array(
+        values, lengths, padding_length, padding_value, _out_dtype=_out_dtype
+    )
+    npt.assert_array_equal(result, expected)
+    assert result.dtype == _out_dtype
+
+
+def test_large_input():
+    """Test with a large number of cities and large padding."""
+    n_cities = 20
+    padding_length = 10
+    padding_value = -1.0
+    lengths = [
+        random.randint(random.PRNGKey(i), minval=1, maxval=padding_length + 1, shape=())
+        for i in range(n_cities)
+    ]
+    values = [float(i) for i in range(n_cities)]
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+
+    assert result.shape == (n_cities, padding_length)
+
+    for i in range(n_cities):
+        length = lengths[i]
+        expected_row = jnp.full((padding_length,), padding_value)
+        if length > 0:
+            expected_row = expected_row.at[:length].set(values[i])
+        npt.assert_allclose(result[i], expected_row)
+
+
+def test_float_array_input():
+    values = [[1.0, 1.1], [2.0, 2.1, 2.2], [3.0, 3.1, 3.2, 3.3]]
+    values = [jnp.asarray(v) for v in values]
+    lengths = [2, 3, 4]
+    padding_length = 4
+    padding_value = 0.0
+
+    expected = jnp.array(
+        [
+            [1.0, 1.1, 0.0, 0.0],
+            [2.0, 2.1, 2.2, 0.0],
+            [3.0, 3.1, 3.2, 3.3],
+        ]
+    )
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+    npt.assert_allclose(result, expected)
+
+
+def test_non_finite_padding_value():
+    """Test with a non-finite padding value (e.g., NaN)."""
+    values = [1.0, 2.0]
+    lengths = [1, 2]
+    padding_length = 3
+    padding_value = float("nan")
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+
+    expected = jnp.array([[1.0, jnp.nan, jnp.nan], [2.0, 2.0, jnp.nan]])
+
+    # Since NaN != NaN, use isnan to check padding positions
+    for i in range(len(lengths)):
+        length = lengths[i]
+        # Check the filled values
+        npt.assert_array_equal(result[i, :length], expected[i, :length])
+        # Check the padding values are NaN
+        if length < padding_length:
+            assert jnp.isnan(result[i, length:]).all()
+
+
+def test_zero_padding_length():
+    """Test with zero padding length."""
+    values = [1.0, 2.0]
+    lengths = [0, 0]
+    padding_length = 0
+    padding_value = 0.0
+
+    expected = jnp.empty((2, 0))
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+    npt.assert_array_equal(result, expected)
+
+
+def test_expected_length_zero_with_padding():
+    """Test with some expected lengths zero and padding_length greater than zero."""
+    values = [1.0, 2.0, 3.0]
+    lengths = [0, 2, 0]
+    padding_length = 3
+    padding_value = -1.0
+
+    expected = jnp.array([[-1.0, -1.0, -1.0], [2.0, 2.0, -1.0], [-1.0, -1.0, -1.0]])
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+    npt.assert_array_equal(result, expected)
+
+
+def test_non_float_values():
+    """Test with integer values and float padding."""
+    values = [1, 2, 3]
+    lengths = [1, 2, 3]
+    padding_length = 4
+    padding_value = 0.5
+
+    expected = jnp.array(
+        [[1.0, 0.5, 0.5, 0.5], [2.0, 2.0, 0.5, 0.5], [3.0, 3.0, 3.0, 0.5]]
+    )
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+    npt.assert_array_equal(result, expected)
+
+
+def test_floating_point_precision():
+    """Test with floating point precision to ensure correct handling."""
+    values = [1.123456789, 2.987654321]
+    lengths = [3, 2]
+    padding_length = 4
+    padding_value = 0.0
+
+    expected = jnp.array(
+        [
+            [1.123456789, 1.123456789, 1.123456789, 0.0],
+            [2.987654321, 2.987654321, 0.0, 0.0],
+        ]
+    )
+
+    result = create_padded_array(values, lengths, padding_length, padding_value)
+    # Use allclose for floating point comparisons
+    npt.assert_allclose(result, expected, atol=1e-8)


### PR DESCRIPTION
This PR aims at the following:

 - [x] Resolve Issue 21: allow overdispersion and quasimultinomial sample size to be specified on a per-timepoint basis.
 - [x] Fix a bug :bug: with parsing the data: currently all the timeseries will be truncated to the length of the last city (i.e., if the last specified city had less points than any other, we were losing data points).