### PR TITLE
Standardize data paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 private/
 # Snakemake-generated files
 generated/
+.snakemake/
 
 .DS_Store
 src/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Private files
 private/
-data/
 # Snakemake-generated files
 generated/
 

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,12 @@
+*.csv
+*.tsv
+*.yml
+*.yaml
+*.pdf
+*.npy
+*.npz
+*.zip
+*.png
+*.pdf
+*.jpg
+*.gif

--- a/data/main/README.md
+++ b/data/main/README.md
@@ -1,0 +1,19 @@
+# Main data set
+
+This is the main data set from which we load the data.
+
+Structure:
+
+data/main
+├── deconvolved.csv
+├── README.md
+└── var_dates.yaml
+
+Checksums:
+```
+$ sha256sum data/main/deconvolved.csv 
+b8dbd93634a6310e13f639eff5402b40d47ed484a905d450b4e0a518d18d0f04  data/main/deconvolved.csv
+
+$ sha256sum data/main/var_dates.yaml 
+a6464599af6859d9542862e081766d31baffd7bc36792a0c671501142f9eda66  data/main/var_dates.yaml
+```

--- a/examples/frequentist_notebook_jax.py
+++ b/examples/frequentist_notebook_jax.py
@@ -24,6 +24,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import pandas as pd
 import yaml
+from pathlib import Path
 
 from covvfit import plot, preprocess
 from covvfit import quasimultinomial as qm
@@ -37,13 +38,9 @@ plot_ts = plot.timeseries
 # We start by loading the data:
 
 # +
-_dir_switch = False  # Change this to True or False, depending on the laptop you are on
-if _dir_switch:
-    DATA_PATH = "../../LolliPop/lollipop_covvfit/deconvolved.csv"
-    VAR_DATES_PATH = "../../LolliPop/lollipop_covvfit/var_dates.yaml"
-else:
-    DATA_PATH = "../new_data/deconvolved.csv"
-    VAR_DATES_PATH = "../new_data/var_dates.yaml"
+DATA_DIR = Path("../data/main/")
+DATA_PATH = DATA_DIR / "deconvolved.csv"
+VAR_DATES_PATH = DATA_DIR / "var_dates.yaml"
 
 
 data = pd.read_csv(DATA_PATH, sep="\t")
@@ -550,4 +547,3 @@ for i, ax in enumerate(axs[:, 1]):
 # Plot individual overdispersions
 for i, ax in enumerate(axs[:, 2]):
     plot_predictions(ax, i, **obtain_predictions(mcmc_indivi))
-# -

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ numpy = "==1.24.3"
 seaborn = "^0.13.2"
 numpyro = "^0.14.0"
 subplots-from-axsize = "^0.1.9"
+pango-aliasor = "^0.3.0"
 
 
 [tool.poetry.group.dev]

--- a/workflows/compare_clinical/.gitignore
+++ b/workflows/compare_clinical/.gitignore
@@ -1,0 +1,2 @@
+results/
+.snakemake/

--- a/workflows/compare_clinical/README.md
+++ b/workflows/compare_clinical/README.md
@@ -1,0 +1,11 @@
+# Comparison with clinical data
+
+To run the workflow, ensure that you have the `data/main` directory set up with the data.
+Note that the workflow should be run from this directory:
+
+Usage:
+
+```bash
+$ snakemake -s compare_clinical.smk --configfile CONFIG_NAME.yaml
+```
+

--- a/workflows/compare_clinical/config_ba1.yaml
+++ b/workflows/compare_clinical/config_ba1.yaml
@@ -1,6 +1,6 @@
 api_url: "https://lapis.cov-spectrum.org/open/v2/sample/aggregated"
 country: "Switzerland"
-wastewater_data_path: "../../../LolliPop/lollipop_covvfit/deconvolved.csv"
+wastewater_data_path: "../../data/main/deconvolved.csv"
 
 run_name: "config_ba1"
 

--- a/workflows/compare_clinical/config_ba1ba2.yaml
+++ b/workflows/compare_clinical/config_ba1ba2.yaml
@@ -1,6 +1,6 @@
 api_url: "https://lapis.cov-spectrum.org/open/v2/sample/aggregated"
 country: "Switzerland"
-wastewater_data_path: "../../../LolliPop/lollipop_covvfit/deconvolved.csv"
+wastewater_data_path: "../../data/main/deconvolved.csv"
 
 run_name: "config_ba1ba2"
 

--- a/workflows/compare_clinical/config_ba4ba5.yaml
+++ b/workflows/compare_clinical/config_ba4ba5.yaml
@@ -1,6 +1,6 @@
 api_url: "https://lapis.cov-spectrum.org/open/v2/sample/aggregated"
 country: "Switzerland"
-wastewater_data_path: "../../../LolliPop/lollipop_covvfit/deconvolved.csv"
+wastewater_data_path: "../../data/main/deconvolved.csv"
 
 run_name: "config_ba4ba5"
 

--- a/workflows/compare_clinical/config_ba4ba5_2.yaml
+++ b/workflows/compare_clinical/config_ba4ba5_2.yaml
@@ -1,6 +1,6 @@
 api_url: "https://lapis.cov-spectrum.org/open/v2/sample/aggregated"
 country: "Switzerland"
-wastewater_data_path: "../../../LolliPop/lollipop_covvfit/deconvolved.csv"
+wastewater_data_path: "../../data/main/deconvolved.csv"
 
 run_name: "config_ba4ba5_2"
 


### PR DESCRIPTION
This PR resolves issue #30, standardizing the data paths, so that we can both run exactly the same notebooks and workflows, without the needs to adjust them.

To start using it, you may will to either copy `deconvolved.csv` and `var_dates.yaml` into the `data/main` directory or create [softlinks](https://www.cyberciti.biz/faq/creating-soft-link-or-symbolic-link/) for them via:

```bash
$ ln -s PATH_TO_DECONVOLVED data/main/deconvolved.csv
$ ln -s PATH_TO_VAR_DATES data/main/var_dates.yaml
```
