### PR TITLE
Evaluate predictions 

### DIFF
--- a/examples/analyze_predictions.py
+++ b/examples/analyze_predictions.py
@@ -1,0 +1,443 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.16.4
+#   kernelspec:
+#     display_name: jax
+#     language: python
+#     name: jax
+# ---
+
+# # Prediction analysis notebook
+#
+# This notebook is to analyze accuracy of prediction.
+
+# +
+import jax
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import pandas as pd
+import yaml
+from pathlib import Path
+
+from covvfit import plot, preprocess
+from covvfit import quasimultinomial as qm
+
+import numpy as np
+
+plot_ts = plot.timeseries
+# -
+
+
+# ## Load and preprocess data
+#
+# We start by loading the data:
+
+# +
+DATA_DIR = Path("../data/main/")
+DATA_PATH = DATA_DIR / "deconvolved.csv"
+VAR_DATES_PATH = DATA_DIR / "var_dates.yaml"
+
+
+data = pd.read_csv(DATA_PATH, sep="\t")
+data.head()
+
+# +
+# %matplotlib inline
+import matplotlib.pyplot as plt
+
+# Set default DPI for high-resolution plots
+plt.rcParams["figure.dpi"] = 300  # Adjust to 150, 200, or more for higher resolution
+
+# +
+# Load the YAML file
+with open(VAR_DATES_PATH, "r") as file:
+    var_dates_data = yaml.safe_load(file)
+
+# Access the var_dates data
+var_dates = var_dates_data["var_dates"]
+
+
+data_wide = data.pivot_table(
+    index=["date", "location"], columns="variant", values="proportion", fill_value=0
+).reset_index()
+data_wide = data_wide.rename(columns={"date": "time", "location": "city"})
+
+# Define the list with cities:
+cities = [
+    "Zürich (ZH)",
+    "Altenrhein (SG)",
+    "Laupen (BE)",
+    "Lugano (TI)",
+    "Chur (GR)",
+    "Genève (GE)",
+]
+
+# -
+
+# Now we look at the variants in the data and define the variants of interest:
+
+# +
+# Convert the keys to datetime objects for comparison
+var_dates_parsed = {
+    pd.to_datetime(date): variants for date, variants in var_dates.items()
+}
+
+
+# Function to find the latest matching date in var_dates
+def match_date(start_date):
+    start_date = pd.to_datetime(start_date)
+    closest_date = max(date for date in var_dates_parsed if date <= start_date)
+    return closest_date, var_dates_parsed[closest_date]
+
+
+variants_full = [
+    "BA.5",
+    "BA.2.75",
+    "BA.2.86",
+    "BQ.1.1",
+    "XBB.1.5",
+    "XBB.1.9",
+    "XBB.1.16",
+    "XBB.2.3",
+    "EG.5",
+    "JN.1",
+]
+
+variants_investigated = [
+    "BA.2.75",
+    "BA.2.86",
+    "BQ.1.1",
+    "XBB.1.5",
+    "XBB.1.9",
+    "XBB.1.16",
+    "XBB.2.3",
+    "EG.5",
+    "JN.1",
+]
+
+variants_other = [
+    i for i in variants_full if i not in variants_investigated
+]  # Variants not of interest
+# -
+
+# Apart from the variants of interest, we define the "other" variant, which artificially merges all the other variants into one. This allows us to model the data as a compositional time series, i.e., the sum of abundances of all "variants" is normalized to one.
+
+# ### functions to be reran at each iteration
+#
+# We will define some functions to be reran at each iteration of the experiment. They will prepare the data from a date to another and fit the model. Then we will output some predictions.
+
+# +
+max_date = pd.to_datetime("2024-01-01")
+start_date = pd.to_datetime("2022-10-21")
+
+
+def prepare_data(data_wide, start_date, max_date):
+    """function to prepare data with the right timespan"""
+
+    data_wide2 = data_wide.copy()
+
+    ## Set limit times for modeling
+    data_wide2["time"] = pd.to_datetime(data_wide2["time"])
+
+    data_wide2 = data_wide2[data_wide2["time"] >= start_date]
+    data_wide2 = data_wide2[data_wide2["time"] <= max_date]
+
+    variants_effective = ["other"] + variants_investigated
+
+    data_full = preprocess.preprocess_df(
+        data_wide2, cities, variants_full, date_min=start_date, zero_date=start_date
+    )
+
+    data_full["other"] = data_full[variants_other].sum(axis=1)
+    data_full[variants_effective] = data_full[variants_effective].div(
+        data_full[variants_effective].sum(axis=1), axis=0
+    )
+
+    ts_lst, ys_effective = preprocess.make_data_list(
+        data_full, cities=cities, variants=variants_effective
+    )
+
+    # Scale the time for numerical stability
+    time_scaler = preprocess.TimeScaler()
+    ts_lst_scaled = time_scaler.fit_transform(ts_lst)
+
+    return {
+        "data_wide2": data_wide2,
+        "ts_lst": ts_lst,
+        "ys_effective": ys_effective,
+        "ts_lst_scaled": ts_lst_scaled,
+        "time_scaler": time_scaler,
+    }
+
+
+# -
+
+# function to make inference and output preductions
+
+
+def inference(ys_effective, ts_lst_scaled, ts_lst, time_scaler, horizon=7):
+    # no priors
+    loss = qm.construct_total_loss(
+        ys=ys_effective,
+        ts=ts_lst_scaled,
+        average_loss=False,  # Do not average the loss over the data points, so that the covariance matrix shrinks with more and more data added
+    )
+
+    variants_effective = ["other"] + variants_investigated
+    n_variants_effective = len(variants_effective)
+    # initial parameters
+    theta0 = qm.construct_theta0(n_cities=len(cities), n_variants=n_variants_effective)
+
+    # Run the optimization routine
+    solution = qm.jax_multistart_minimize(loss, theta0, n_starts=10)
+    theta_star = solution.x  # The maximum quasilikelihood estimate
+
+    ts_pred_lst = [jnp.arange(horizon + 1) + tt.max() for tt in ts_lst]
+    ts_pred_lst_scaled = time_scaler.transform(ts_pred_lst)
+
+    ys_pred = qm.fitted_values(
+        ts_pred_lst_scaled,
+        theta=theta_star,
+        cities=cities,
+        n_variants=n_variants_effective,
+    )
+
+    return {
+        "ys_pred": ys_pred,
+        "ts_pred_lst": ts_pred_lst,
+        "solution": solution,
+    }
+
+
+# ## Prepare smoothed data for comparison
+#
+# We will smooth wastewater deconvolved data to average out the sampling noise. This will give us a better baseline to compare our predictions to.
+
+# +
+import numpy as np
+
+
+def gaussian_kernel(t, ts, sigma):
+    """Compute Gaussian weights for a given t"""
+    return np.exp(-0.5 * ((ts - t) / sigma) ** 2) / (sigma * np.sqrt(2 * np.pi))
+
+
+def smooth_value(t, ts, ys, sigma):
+    """Compute the smoothed value at time t using a Gaussian-weighted average."""
+    weights = gaussian_kernel(t, ts, sigma)
+    weights /= weights.sum()  # Normalize weights
+    return np.dot(weights, ys)
+
+
+def smooth_value_median(t, ts, ys, sigma):
+    """Compute the smoothed value at time t using a Gaussian-weighted median for each dimension in ys."""
+    weights = gaussian_kernel(t, ts, sigma)
+    sorted_indices = np.argsort(ys, axis=0)
+    ys_sorted = np.take_along_axis(ys, sorted_indices, axis=0)
+    weights_sorted = np.take_along_axis(weights[:, np.newaxis], sorted_indices, axis=0)
+    cumsum_weights = np.cumsum(weights_sorted, axis=0)
+    median_indices = np.argmax(cumsum_weights >= 0.5 * cumsum_weights[-1], axis=0)
+    return np.take_along_axis(ys_sorted, median_indices[np.newaxis, :], axis=0)[0]
+
+
+def smooth_array(tt, ts, ys, sigma, method="mean"):
+    """Compute smoothed values for an array of t values."""
+    if method == "mean":
+        return np.array([smooth_value(t, ts, ys, sigma) for t in tt])
+    if method == "median":
+        return np.array([smooth_value_median(t, ts, ys, sigma) for t in tt])
+
+
+# -
+
+# smooth the data. make sure to include data away from the time boundaries of the experiment to avoid common biases from kernel smoothing
+
+# +
+sigma = 15
+
+prep_dat_full = prepare_data(data_wide, start_date, pd.to_datetime("2024-04-01"))
+
+ys_lst_full = prep_dat_full["ys_effective"]
+ts_lst_full = prep_dat_full["ts_lst"]
+
+ts_lst_smooth = []
+ys_lst_smooth = []
+for i in range(len(ys_lst_full)):
+    min_t = int(ts_lst_full[i].min())
+    max_t = int(ts_lst_full[i].max())
+    ts_tmp = np.linspace(min_t, max_t, max_t - min_t + 1)
+    ys_smooth = smooth_array(
+        ts_tmp, ts_lst_full[i], ys_lst_full[i], sigma=sigma, method="median"
+    )
+
+    ts_lst_smooth.append(ts_tmp)
+    ys_lst_smooth.append(ys_smooth)
+# -
+
+# Let's plot the smoothing
+
+# +
+colors = [plot_ts.COLORS_COVSPECTRUM[var] for var in variants_investigated]
+
+
+def remove_0th(arr):
+    """We don't plot the artificial 0th variant 'other'."""
+    return arr[:, 1:]
+
+
+fig, axes = plt.subplots(3, 2)
+axes = axes.flatten()
+
+for i, city in enumerate(cities):
+    ax = axes[i]
+    plot_ts.plot_data(ax, ts_lst_full[i], remove_0th(ys_lst_full[i]), colors=colors)
+    plot_ts.plot_fit(ax, ts_lst_smooth[i], remove_0th(ys_lst_smooth[i]), colors=colors)
+    # ax.set_xlim((300,ts_lst_full[i].max()))
+
+    def format_date(x, pos):
+        return plot_ts.num_to_date(x, date_min=start_date)
+
+    date_formatter = ticker.FuncFormatter(format_date)
+    ax.xaxis.set_major_formatter(date_formatter)
+
+plt.tight_layout()
+plt.show()
+
+# -
+
+# # make a comparison
+
+# Let's define functions to make the comparison between predicted and smoothed
+
+
+# +
+def compare(ts_in, ys_in, ts_smooth, ys_smooth):
+    """Compare predicted data ys_in at ts_in with smoothed data ys_smooth at ts_smooth."""
+    indices = np.where(np.isin(ts_smooth, ts_in))[0]
+    if len(indices) == 0:
+        raise ValueError("No matching time points found in ts_smooth")
+
+    differences = ys_in - ys_smooth[indices]
+    relative_differences = differences / ys_smooth[indices]
+    return (differences, relative_differences)
+
+
+def compare_all(ts_lst_pred, ys_lst_pred, ts_lst_smooth, ys_lst_smooth):
+    """Compare all time series in the given lists."""
+    all_differences = []
+    all_relative_differences = []
+    for ts_in, ys_in, ts_smooth, ys_smooth in zip(
+        ts_lst_pred, ys_lst_pred, ts_lst_smooth, ys_lst_smooth
+    ):
+        differences, relative_differences = compare(ts_in, ys_in, ts_smooth, ys_smooth)
+        all_differences.append(differences)
+        all_relative_differences.append(relative_differences)
+    return (all_differences, all_relative_differences)
+
+
+# -
+
+# define when are the dates we want to fit at and predict, run the experiment
+
+# +
+# Generate list of max_dates from 2023-08-01 to 2023-11-01
+max_dates = pd.date_range(start="2023-08-01", end="2024-01-01", freq="D")
+
+# Initialize list to store results
+all_differences_results = []
+all_relative_differences_results = []
+
+# Loop through max_dates and perform comparisons
+for max_date in max_dates:
+    prep_dat = prepare_data(data_wide, start_date, max_date)
+
+    inf_dat = inference(
+        prep_dat["ys_effective"],
+        prep_dat["ts_lst_scaled"],
+        prep_dat["ts_lst"],
+        prep_dat["time_scaler"],
+        horizon=45,
+    )
+
+    diff_res, rel_diff_res = compare_all(
+        inf_dat["ts_pred_lst"], inf_dat["ys_pred"], ts_lst_smooth, ys_lst_smooth
+    )
+
+    all_differences_results.append(diff_res)
+    all_relative_differences_results.append(rel_diff_res)
+# -
+
+
+# ## plot the results
+
+# +
+all_differences_results_array = np.array(all_differences_results)
+all_relative_differences_results_array = np.array(all_relative_differences_results)
+print(all_differences_results_array.shape)
+
+fig, axes = plt.subplots(2, 3, figsize=(10, 5), sharex="col", sharey="row")
+# axes = axes.flatten()
+
+variants_effective = ["other"] + variants_investigated
+
+for i, variant in enumerate([9, 2, 8]):
+    ## Plot time series
+    ax = axes[0, i]
+    dates_points = start_date + pd.to_timedelta(ts_lst_full[0], "D")
+    ax.scatter(dates_points, ys_lst_full[0][:, variant])
+    dates_smooth = start_date + pd.to_timedelta(ts_lst_smooth[0], "D")
+    ax.plot(dates_smooth, ys_lst_smooth[0][:, variant])
+    ax.set_xlim(pd.to_datetime(["2023-08-01", "2024-01-01"]))
+    ax.set_title(variants_effective[variant])
+    ax.set_ylabel("rel. abundance")
+
+    ## plot mean error
+
+    ax = axes[1, i]
+    for horizon in [0, 7, 14, 21, 28, 35, 42]:
+        ax.plot(
+            max_dates,
+            all_differences_results_array.mean(axis=1)[:, horizon, variant],
+            label=f"horizon={int(horizon/7)}[week]",
+        )
+        # ax.legend()
+        ax.set_ylabel("mean forecast error")
+        ax.set_ylim((-0.5, 0.5))
+
+    ## plot mean absolute relative error
+
+    # ax=axes[2,i]
+    # for horizon in [0,7,14,21]:
+    #     ax.plot(
+    #         max_dates,
+    #         np.abs(all_relative_differences_results_array[:,:,horizon,variant]).mean(axis=1),
+    #         label=f"horizon={horizon}[d]"
+    #     )
+    #     ax.set_ylim((0,2))
+    #     ax.set_ylabel("mean abs rel error")
+
+# Deduplicate legend entries
+handles, labels = axes[1, 0].get_legend_handles_labels()
+unique_labels = {}
+unique_handles = []
+for handle, label in zip(handles, labels):
+    if label not in unique_labels:
+        unique_labels[label] = handle
+        unique_handles.append((handle, label))
+
+# Add unique legend
+fig.legend(
+    [h for h, _ in unique_handles],
+    [l for _, l in unique_handles],
+    loc="center left",
+    bbox_to_anchor=(1, 0.5),
+)
+fig.tight_layout()
+plt.show()

--- a/workflows/evaluate_predictions/.gitignore
+++ b/workflows/evaluate_predictions/.gitignore
@@ -1,0 +1,4 @@
+results/
+.snakemake/
+config_xbb.yaml
+

--- a/workflows/evaluate_predictions/config_ba1ba2.yaml
+++ b/workflows/evaluate_predictions/config_ba1ba2.yaml
@@ -1,0 +1,43 @@
+run_name: "ba1ba2"
+
+# Data paths
+data_dir: "../../data/main"
+data_file: "deconvolved.csv"
+var_dates_file: "var_dates.yaml"
+
+# City list
+cities:
+  - "Zürich (ZH)"
+  - "Altenrhein (SG)"
+  - "Laupen (BE)"
+  - "Lugano (TI)"
+  - "Chur (GR)"
+  - "Genève (GE)"
+
+# Variants information
+variants_full:
+  - "B.1.617.2"
+  - "BA.1"
+  - "BA.2"
+
+variants_investigated:
+  - "BA.1"
+  - "BA.2"
+
+variants_evaluated:
+  - "BA.1"
+  - "BA.2"
+
+# Date parameters
+start_date: "2021-11-20"
+max_date: "2022-02-28"
+max_dates: 
+  start: "2021-11-27"
+  end: "2022-02-28"
+
+# Prediction settings
+max_horizon: 45
+
+# Smoothing parameters
+sigma: 15
+smoothing_method: "median"

--- a/workflows/evaluate_predictions/config_jn1.yaml
+++ b/workflows/evaluate_predictions/config_jn1.yaml
@@ -1,0 +1,58 @@
+run_name: "jn1"
+
+# Data paths
+data_dir: "../../data/main"
+data_file: "deconvolved.csv"
+var_dates_file: "var_dates.yaml"
+
+# City list
+cities:
+  - "Zürich (ZH)"
+  - "Altenrhein (SG)"
+  - "Laupen (BE)"
+  - "Lugano (TI)"
+  - "Chur (GR)"
+  - "Genève (GE)"
+
+# Variants information
+variants_full:
+  - "BA.5"
+  - "BA.2.75"
+  - "BA.2.86"
+  - "BQ.1.1"
+  - "XBB.1.5"
+  - "XBB.1.9"
+  - "XBB.1.16"
+  - "XBB.2.3"
+  - "EG.5"
+  - "JN.1"
+
+variants_investigated:
+  - "BA.2.75"
+  - "BA.2.86"
+  - "BQ.1.1"
+  - "XBB.1.5"
+  - "XBB.1.9"
+  - "XBB.1.16"
+  - "XBB.2.3"
+  - "EG.5"
+  - "JN.1"
+
+variants_evaluated:
+  - "BA.2.86"
+  - "EG.5"
+  - "JN.1"
+
+# Date parameters
+start_date: "2022-10-21"
+max_date: "2024-01-01"
+max_dates: 
+  start: "2023-08-01"
+  end: "2024-01-01"
+
+# Prediction settings
+max_horizon: 45
+
+# Smoothing parameters
+sigma: 15
+smoothing_method: "median"

--- a/workflows/evaluate_predictions/eval_pred.smk
+++ b/workflows/evaluate_predictions/eval_pred.smk
@@ -1,0 +1,264 @@
+import jax
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import pandas as pd
+import yaml
+from pathlib import Path
+
+from covvfit import plot, preprocess
+from covvfit import quasimultinomial as qm
+
+import numpy as np
+import pickle
+
+plot_ts = plot.timeseries
+
+run_name = config["run_name"]
+
+DATA_DIR = Path("../../data/main/")
+DATA_PATH = DATA_DIR / "deconvolved.csv"
+VAR_DATES_PATH = DATA_DIR / "var_dates.yaml"
+
+# Define the list with cities:
+cities = config["cities"]
+variants_full = config["variants_full"]
+variants_investigated = config["variants_investigated"]
+variants_other = [
+    i for i in variants_full if i not in variants_investigated
+]  # Variants not of interest
+variants_evaluated = config["variants_evaluated"]
+
+# date parameters for the range of the simulation 
+
+max_date = pd.to_datetime(config["max_date"])
+start_date = pd.to_datetime(config["start_date"])
+max_dates = pd.date_range(
+    start=config["max_dates"]["start"],
+    end=config["max_dates"]["end"],
+    freq='D'
+      )
+max_horizon = config["max_horizon"]
+
+# smoothing parameters:
+sigma = config["sigma"]
+smoothing_method = config["smoothing_method"]
+max_smooth_date = max_date + pd.to_timedelta(3*sigma + max_horizon, "D")
+
+## function definitions
+
+def prepare_data(data_wide, start_date, max_date):
+    """function to prepare data with the right timespan"""
+
+    data_wide2 = data_wide.copy()
+
+    ## Set limit times for modeling
+    data_wide2["time"] = pd.to_datetime(data_wide2["time"])
+    
+    data_wide2 = data_wide2[data_wide2["time"] >= start_date]
+    data_wide2 = data_wide2[data_wide2["time"] <= max_date]
+
+    variants_effective = ["other"] + variants_investigated
+
+    
+    data_full = preprocess.preprocess_df(
+        data_wide2, cities, variants_full, date_min=start_date, zero_date=start_date
+    )
+    
+    data_full["other"] = data_full[variants_other].sum(axis=1)
+    data_full[variants_effective] = data_full[variants_effective].div(
+        data_full[variants_effective].sum(axis=1), axis=0
+    )
+
+    ts_lst, ys_effective = preprocess.make_data_list(
+        data_full, cities=cities, variants=variants_effective
+    )
+    
+    # Scale the time for numerical stability
+    time_scaler = preprocess.TimeScaler()
+    ts_lst_scaled = time_scaler.fit_transform(ts_lst)
+
+    return {
+        "data_wide2":data_wide2,
+        "ts_lst":ts_lst,
+        "ys_effective":ys_effective,
+        "ts_lst_scaled":ts_lst_scaled,
+        "time_scaler":time_scaler,
+    }
+
+def inference(ys_effective, ts_lst_scaled, ts_lst, time_scaler, horizon=7):
+    # no priors
+    loss = qm.construct_total_loss(
+        ys=ys_effective,
+        ts=ts_lst_scaled,
+        average_loss=False,  # Do not average the loss over the data points, so that the covariance matrix shrinks with more and more data added
+    )
+    
+    variants_effective = ["other"] + variants_investigated
+    n_variants_effective = len(variants_effective)
+    # initial parameters
+    theta0 = qm.construct_theta0(n_cities=len(cities), n_variants=n_variants_effective)
+
+    # Run the optimization routine
+    solution = qm.jax_multistart_minimize(loss, theta0, n_starts=10)
+    theta_star = solution.x  # The maximum quasilikelihood estimate
+
+    ts_pred_lst = [jnp.arange(horizon + 1) + tt.max() for tt in ts_lst]
+    ts_pred_lst_scaled = time_scaler.transform(ts_pred_lst)
+    
+    ys_pred = qm.fitted_values(
+        ts_pred_lst_scaled, theta=theta_star, cities=cities, n_variants=n_variants_effective
+    )
+
+    return {
+        "ys_pred":ys_pred,
+        "ts_pred_lst":ts_pred_lst,
+        "solution":solution,
+    }
+
+def gaussian_kernel(t, ts, sigma):
+    """Compute Gaussian weights for a given t"""
+    return np.exp(-0.5 * ((ts - t) / sigma) ** 2) / (sigma * np.sqrt(2 * np.pi))
+
+def smooth_value(t, ts, ys, sigma):
+    """Compute the smoothed value at time t using a Gaussian-weighted average."""
+    weights = gaussian_kernel(t, ts, sigma)
+    weights /= weights.sum()  # Normalize weights
+    return np.dot(weights, ys)
+
+def smooth_value_median(t, ts, ys, sigma):
+    """Compute the smoothed value at time t using a Gaussian-weighted median for each dimension in ys."""
+    weights = gaussian_kernel(t, ts, sigma)
+    sorted_indices = np.argsort(ys, axis=0)
+    ys_sorted = np.take_along_axis(ys, sorted_indices, axis=0)
+    weights_sorted = np.take_along_axis(weights[:, np.newaxis], sorted_indices, axis=0)
+    cumsum_weights = np.cumsum(weights_sorted, axis=0)
+    median_indices = np.argmax(cumsum_weights >= 0.5 * cumsum_weights[-1], axis=0)
+    return np.take_along_axis(ys_sorted, median_indices[np.newaxis, :], axis=0)[0]
+
+def smooth_array(tt, ts, ys, sigma, method="mean"):
+    """Compute smoothed values for an array of t values."""
+    if method=="mean":
+        return np.array([smooth_value(t, ts, ys, sigma) for t in tt])
+    if method=="median":
+        return np.array([smooth_value_median(t, ts, ys, sigma) for t in tt])
+
+def compare(ts_in, ys_in, ts_smooth, ys_smooth):
+    """Compare predicted data ys_in at ts_in with smoothed data ys_smooth at ts_smooth."""
+    indices = np.where(np.isin(ts_smooth, ts_in))[0]
+    if len(indices) == 0:
+        raise ValueError("No matching time points found in ts_smooth")
+    
+    differences = ys_in - ys_smooth[indices]
+    relative_differences = differences / ys_smooth[indices]
+    return (differences , relative_differences)
+
+def compare_all(ts_lst_pred, ys_lst_pred, ts_lst_smooth, ys_lst_smooth):
+    """Compare all time series in the given lists."""
+    all_differences = []
+    all_relative_differences = []
+    for ts_in, ys_in, ts_smooth, ys_smooth in zip(ts_lst_pred, ys_lst_pred, ts_lst_smooth, ys_lst_smooth):
+        differences, relative_differences = compare(ts_in, ys_in, ts_smooth, ys_smooth)
+        all_differences.append(differences)
+        all_relative_differences.append(relative_differences)
+    return (all_differences, all_relative_differences)
+
+# Rule all
+rule all:
+    input:
+        f"results/{run_name}/diff_array.npy",
+        f"results/{run_name}/rel_diff_array.npy",
+        f"results/{run_name}/ys_lst_full.pkl",
+        f"results/{run_name}/ts_lst_full.pkl",
+        f"results/{run_name}/ts_lst_smooth.pkl",
+        f"results/{run_name}/ys_lst_smooth.pkl"
+
+rule run_experiment:
+    output:
+        f"results/{run_name}/diff_array.npy",
+        f"results/{run_name}/rel_diff_array.npy",
+        f"results/{run_name}/ys_lst_full.pkl",
+        f"results/{run_name}/ts_lst_full.pkl",
+        f"results/{run_name}/ts_lst_smooth.pkl",
+        f"results/{run_name}/ys_lst_smooth.pkl"
+    run:
+
+        ## load the data
+        data = pd.read_csv(DATA_PATH, sep="\t")
+        data_wide = data.pivot_table(
+            index=["date", "location"], columns="variant", values="proportion", fill_value=0
+        ).reset_index()
+        data_wide = data_wide.rename(columns={"date": "time", "location": "city"})
+
+        # Load the YAML file
+        with open(VAR_DATES_PATH, "r") as file:
+            var_dates_data = yaml.safe_load(file)
+
+        # Access the var_dates data
+        var_dates = var_dates_data["var_dates"]
+
+        ## make the smoothing:
+
+        prep_dat_full = prepare_data(data_wide, start_date, max_smooth_date)
+
+        ys_lst_full = prep_dat_full["ys_effective"]
+        ts_lst_full = prep_dat_full["ts_lst"]
+
+        ts_lst_smooth = []
+        ys_lst_smooth = []
+        for i in range(len(ys_lst_full)):
+            min_t = int(ts_lst_full[i].min())
+            max_t = int(ts_lst_full[i].max())
+            ts_tmp = np.linspace(min_t, max_t, max_t-min_t+1)
+            ys_smooth = smooth_array(ts_tmp, ts_lst_full[i], ys_lst_full[i], sigma=sigma, method=smoothing_method)
+            
+            ts_lst_smooth.append(ts_tmp)
+            ys_lst_smooth.append(ys_smooth)
+
+        # Save smoothed etc
+        with open(f"results/{run_name}/ys_lst_full.pkl", "wb") as f:
+            pickle.dump(ys_lst_full, f)
+        with open(f"results/{run_name}/ts_lst_full.pkl", "wb") as f:
+            pickle.dump(ts_lst_full, f)
+        with open(f"results/{run_name}/ts_lst_smooth.pkl", "wb") as f:
+            pickle.dump(ts_lst_smooth, f)
+        with open(f"results/{run_name}/ys_lst_smooth.pkl", "wb") as f:
+            pickle.dump(ys_lst_smooth, f)
+
+        import tqdm
+        import warnings
+
+        # Initialize list to store results
+        all_differences_results = []
+        all_relative_differences_results = []
+
+        # Loop through max_dates and perform 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            for max_date in tqdm.tqdm(max_dates, leave=False):
+                prep_dat = prepare_data(data_wide, start_date, max_date)
+                
+                inf_dat = inference(
+                    prep_dat["ys_effective"],
+                    prep_dat["ts_lst_scaled"],
+                    prep_dat["ts_lst"],
+                    prep_dat["time_scaler"],
+                    horizon=max_horizon,
+                )
+                
+                diff_res, rel_diff_res = compare_all(inf_dat["ts_pred_lst"], inf_dat["ys_pred"], ts_lst_smooth, ys_lst_smooth)
+                
+                all_differences_results.append(diff_res)
+                all_relative_differences_results.append(rel_diff_res)
+
+        all_differences_results_array = np.array(all_differences_results)
+        all_relative_differences_results_array = np.array(all_relative_differences_results)
+
+        np.save(f"results/{run_name}/diff_array.npy", all_differences_results_array)
+        np.save(f"results/{run_name}/rel_diff_array.npy", all_relative_differences_results_array)
+
+
+
+
+
+

--- a/workflows/evaluate_predictions/view_predictions.py
+++ b/workflows/evaluate_predictions/view_predictions.py
@@ -1,0 +1,337 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.4
+#   kernelspec:
+#     display_name: jax
+#     language: python
+#     name: jax
+# ---
+
+# %%
+import os
+import pickle
+import string
+
+import matplotlib.cm as cm
+import matplotlib.colors as mcolors
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import yaml
+from covvfit import plot
+
+plot_ts = plot.timeseries
+
+# %%
+# %matplotlib inline
+
+# Set default DPI for high-resolution plots
+plt.rcParams["figure.dpi"] = 300  # Adjust to 150, 200, or more for higher resolution
+
+
+# %% [markdown]
+# # load data from the runs
+
+
+# %%
+def load_data(directory):
+    """Load all output files from a run."""
+    data = {}
+
+    # Load numpy arrays
+    for filename in ["diff_array.npy", "rel_diff_array.npy"]:
+        path = os.path.join(directory, filename)
+        if os.path.exists(path):
+            data[filename.split(".")[0]] = np.load(path)
+
+    # Load pickle files
+    for filename in [
+        "ys_lst_full.pkl",
+        "ts_lst_full.pkl",
+        "ts_lst_smooth.pkl",
+        "ys_lst_smooth.pkl",
+    ]:
+        path = os.path.join(directory, filename)
+        if os.path.exists(path):
+            with open(path, "rb") as f:
+                data[filename.split(".")[0]] = pickle.load(f)
+
+    return data
+
+
+# %%
+ba1ba2 = load_data("results/ba1ba2/")
+with open("config_ba1ba2.yaml", "r") as file:
+    ba1ba2_config = yaml.safe_load(file)
+
+jn1 = load_data("results/jn1/")
+with open("config_jn1.yaml", "r") as file:
+    jn1_config = yaml.safe_load(file)
+
+
+ba1ba2_config["variants_evaluated"] = ["other"] + ba1ba2_config["variants_evaluated"]
+
+all_configs = [ba1ba2_config, jn1_config]
+all_data = [ba1ba2, jn1]
+
+# %%
+# np.array(["other"] + xbb_config["variants_investigated"])[np.argsort(xbb["ys_lst_smooth"][0].mean(axis=0))]
+
+
+# %% [markdown]
+# # Plot results
+
+# %%
+# Define colormap for error plotting
+cmap = cm.coolwarm
+colors_covsp = plot_ts.COLORS_COVSPECTRUM
+colors_covsp["other"] = "#969696"
+
+horizons = [0, 7, 14, 21, 30, 45]
+
+# Create a 5-row subplot layout to include the new row
+fig, axes = plt.subplots(
+    5,
+    len(all_configs),
+    figsize=(12, 10),  # Increase figure height to accommodate extra row
+    # sharex="col",
+    sharey="row",
+    gridspec_kw={"hspace": 0.55},  # Adjust vertical spacing
+)
+
+norm = mcolors.Normalize(vmin=min(horizons), vmax=max(horizons))
+colors = [cmap(norm(h)) for h in horizons]
+
+for k, (config, proc_data) in enumerate(zip(all_configs, all_data)):
+    variants_investigated = config["variants_investigated"]
+    variants_effective = ["other"] + variants_investigated
+    variants_evaluated = config["variants_evaluated"]
+    start_date = pd.to_datetime(config["start_date"])
+    max_dates = pd.date_range(
+        start=config["max_dates"]["start"], end=config["max_dates"]["end"], freq="D"
+    )
+    (
+        diff_array,
+        rel_diff_array,
+        ys_lst_full,
+        ts_lst_full,
+        ts_lst_smooth,
+        ys_lst_smooth,
+    ) = proc_data.values()
+
+    ax = axes[0, k]
+    ## Plot the rel abundance of the unstudied variants
+    variants_notevaluated = [
+        i for i in variants_investigated if i not in variants_evaluated
+    ]
+    variants_notevaluated_index = np.where(
+        np.isin(variants_effective, variants_notevaluated)
+    )[0]
+
+    dates_points = start_date + pd.to_timedelta(ts_lst_full[0], "D")
+    dates_smooth = start_date + pd.to_timedelta(ts_lst_smooth[0], "D")
+
+    for var_idx, var_name in zip(variants_notevaluated_index, variants_notevaluated):
+        ax.plot(
+            dates_smooth,
+            ys_lst_smooth[0][:, var_idx],
+            c=colors_covsp[var_name],
+            alpha=0.25,
+            label=var_name,
+        )
+
+    ## Plot the rel abundance of the studied variants
+    variants_evaluated_index = np.where(
+        np.isin(variants_effective, variants_evaluated)
+    )[0]
+
+    for var_idx, var_name in zip(variants_evaluated_index, variants_evaluated):
+        ax.scatter(
+            dates_points, ys_lst_full[0][:, var_idx], c=colors_covsp[var_name], s=2
+        )
+        ax.plot(
+            dates_smooth,
+            ys_lst_smooth[0][:, var_idx],
+            c=colors_covsp[var_name],
+            label=var_name,
+        )
+    ax.set_xlim(max_dates.min(), max_dates.max())
+    ax.set_ylabel("rel. abundance")
+    ax.set_title("smoothed deconvolved rel. abundances")
+
+    ## Plot error
+    for i, (var_idx, var_name) in enumerate(
+        zip(variants_evaluated_index, variants_evaluated)
+    ):
+        ax = axes[1 + i, k]
+        for j, horizon in enumerate(horizons):
+            ax.plot(
+                max_dates,
+                diff_array.mean(axis=1)[:, horizon, var_idx],
+                label=f"{int(horizon/7)}",
+                color=colors[j],
+            )
+        ax.set_ylabel("mean err.")
+        ax.set_ylim((-0.5, 0.5))
+        ax.set_title(f"{var_name} pred. error")
+        ax.tick_params(axis="x", rotation=0)
+
+    ## New row: Boxplot analysis for variants_evaluated
+    ax = axes[4, k]
+
+    # Compute break index
+    break_index = np.mean(
+        [np.where(smooth[:, -1] >= 0.1)[0][0] for smooth in ys_lst_smooth]
+    )
+    max_dates_idx = (
+        max_dates - pd.to_datetime(config["start_date"])
+    ) / pd.to_timedelta(1, "D")
+
+    err_before = diff_array[max_dates_idx < break_index, :, :, :]
+    err_after = diff_array[max_dates_idx >= break_index, :, :, :]
+
+    # Get the number of groups from the last index dimension
+    num_groups = err_before.shape[-1]
+
+    # Prepare data for boxplot (only for variants_evaluated)
+    boxplot_data = []
+    boxplot_labels = []
+    boxplot_colors = []
+    horizon_positions = []
+
+    for i, (condition, h) in enumerate(
+        [(c, h) for c in ["Before", "After"] for h in horizons]
+    ):
+        for var_idx, var_name in zip(variants_evaluated_index, variants_evaluated):
+            if condition == "Before":
+                data_subset = np.abs(err_before[:, :, h, var_idx]).flatten()
+            else:
+                data_subset = np.abs(err_after[:, :, h, var_idx]).flatten()
+
+            boxplot_data.append(data_subset)
+            boxplot_labels.append(f"{condition}-{h}-{var_name}")
+            boxplot_colors.append(colors_covsp[var_name])
+
+    horizon_positions = [2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 32, 35]
+
+    # Create the boxplot
+    box = ax.boxplot(
+        boxplot_data,
+        labels=boxplot_labels,
+        patch_artist=True,
+    )
+
+    # Apply colors based on the variant
+    for patch, flier, median, color in zip(
+        box["boxes"], box["fliers"], box["medians"], boxplot_colors
+    ):
+        patch.set_facecolor(color)  # Set box interior color
+        patch.set_edgecolor("black")  # Set thin black outline
+        flier.set(
+            marker=".",
+            markerfacecolor=color,
+            markeredgecolor=color,
+            markersize=1,
+            linestyle="none",
+        )
+        median.set(color="black")
+
+    # Set x-ticks only at horizon positions
+    ax.set_xticks(horizon_positions)
+    ax.set_xticklabels(horizons * 2, rotation=45)
+    ax.set_ylabel("abs. err.")
+    ax.set_xlabel("horizon (days)")
+    ax.set_title("abs. pred. error before/after cutoff")
+
+
+## Legend for horizons
+# Deduplicate legend entries
+handles, labels = axes[3, 1].get_legend_handles_labels()
+unique_labels = {}
+unique_handles = []
+for handle, label in zip(handles, labels):
+    if label not in unique_labels:
+        unique_labels[label] = handle
+        unique_handles.append((handle, label))
+
+# Add unique legend
+fig.legend(
+    [h for h, _ in unique_handles],
+    [z for _, z in unique_handles],
+    loc="center",
+    bbox_to_anchor=(1, 0.5),
+    title="horizon (weeks)",
+)
+
+## Legend for variants
+# Create a dictionary to store legend handles for variants
+variant_handles = {}
+
+# Collect variant legend handles from the first row of axes
+for k in range(len(all_configs)):  # Iterate over columns
+    handles, labels = axes[0, k].get_legend_handles_labels()
+    for handle, label in zip(handles, labels):
+        if label not in variant_handles:
+            variant_handles[label] = handle  # Store unique handles
+
+# Extract unique handles and labels
+variant_legend_handles = list(variant_handles.values())
+variant_legend_labels = list(variant_handles.keys())
+
+# Add the variant legend above the horizon legend
+fig.legend(
+    variant_legend_handles,
+    variant_legend_labels,
+    loc="upper center",
+    bbox_to_anchor=(1, 0.9),
+    title="Variants",
+)
+
+# Add the existing horizon legend below it
+fig.legend(
+    [h for h, _ in unique_handles],
+    [z for _, z in unique_handles],
+    loc="center",
+    bbox_to_anchor=(1, 0.5),
+    title="Horizon (weeks)",
+)
+
+# Share x-axis for rows 0,1,2,3 within each column
+for k in range(len(all_configs)):  # Iterate over columns
+    for row in range(1, 4):  # Rows 1,2,3 share x-axis with row 0 in the same column
+        axes[row, k].sharex(axes[0, k])
+
+
+for k in range(len(all_configs)):  # Iterate over columns
+    axes[0, k].xaxis.set_major_locator(
+        mdates.MonthLocator(bymonthday=1)
+    )  # First day of each month
+    axes[0, k].xaxis.set_major_formatter(
+        mdates.DateFormatter("%b '%y")
+    )  # Format: "Jan '21"
+
+# Generate panel labels: a, b, c, d, e, f, g, ...
+panel_labels = list(string.ascii_lowercase)
+
+# Loop through all subplots and label them
+for row in range(5):  # 5 rows
+    for col in range(len(all_configs)):  # Number of columns
+        axes[row, col].text(
+            -0.1,
+            1.2,  # Position: slightly above each subplot
+            panel_labels[row * len(all_configs) + col],  # Get the next letter
+            transform=axes[row, col].transAxes,  # Use subplot-relative coordinates
+            fontsize=12,
+            fontweight="bold",
+            va="top",
+            ha="right",
+        )
+
+fig.tight_layout()
+plt.show()


### PR DESCRIPTION
Evaluate prediction performances. 

- Added a short snakemake which computes predictions at different timepoints, for different horizon times. Compares the predictions with a smoothed time series. Computes prediction errors. Output time series and errors. 

- Added two configuration yamls to run this experiment on two different portions of the time series. 

- Added a notebook to pick up the results and plot them. 