### PR TITLE
Add patch for logsumexp_excluding_column

### DIFF
--- a/docs/api/numeric.md
+++ b/docs/api/numeric.md
@@ -28,3 +28,5 @@ covvfit.numeric.some_function()
 ::: covvfit.numeric.log_matrix
 
 ::: covvfit.numeric.log1mexp
+
+::: covvfit.numeric.logsumexp_excluding_column

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
-site_name: Inference of SARS-Cov-2 variant fitness
+site_name: "Inference of variant fitness with Covvfit"
 
 theme:
+  icon:
+    logo: fontawesome/solid/virus-covid
   name: "material"
   features:
     - navigation.tabs

--- a/src/covvfit/_numeric.py
+++ b/src/covvfit/_numeric.py
@@ -3,6 +3,7 @@ import dataclasses
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.scipy.special import logsumexp
 from jaxtyping import Array, Float
 from scipy import optimize
 
@@ -41,6 +42,53 @@ def log1mexp(x: Float[Array, " *shape"]) -> Float[Array, " *shape"]:
     """
     x = jnp.minimum(x, -jnp.finfo(x.dtype).eps)
     return jnp.where(x > -0.693, jnp.log(-jnp.expm1(x)), jnp.log1p(-jnp.exp(x)))
+
+
+def logsumexp_excluding_column(
+    y: Float[Array, "*batch variants"],
+    axis: int = -1,
+) -> Float[Array, "*batch variants"]:
+    """
+    Compute logsumexp across the given axis for each element, excluding
+    the 'current' element at that axis index.
+
+    Args:
+        y: An array of shape [..., variants, ...].
+        axis: The axis along which we exclude each index before computing
+              logsumexp.
+
+    Returns:
+        An array of the same shape as `y`, whose element at index i along
+        `axis` is the log-sum-exp of all other entries (j != i).
+    """
+    # Number of elements along the specified axis
+    n = y.shape[axis]
+    dtype = y.dtype
+
+    # This function will exclude the i-th entry along `axis` by masking it.
+    def exclude_index(i: int) -> jnp.ndarray:
+        # Create a 1D mask of length n: True for j != i, False for j == i
+        mask_1d = jnp.arange(n) != i
+
+        # Reshape it so it can broadcast along the desired `axis`
+        # e.g., if y.ndim=3 and axis=1, shape might be (1, n, 1)
+        mask_shape = [1] * y.ndim
+        mask_shape[axis] = n
+        mask_1d = mask_1d.reshape(mask_shape)
+
+        # Replace the excluded positions with -∞
+        masked_y = jnp.where(mask_1d, y, jnp.finfo(dtype).min)
+
+        # Compute logsumexp over the masked array along `axis`
+        return logsumexp(masked_y, axis=axis)
+
+    # Vectorize over each index (0...n-1) in the chosen axis
+    # This produces a new array with shape=(n, [all the other axes]).
+    results = jax.vmap(exclude_index)(jnp.arange(n))
+
+    # Move the new axis (of length n) back to `axis`, matching the original shape of y
+    results = jnp.moveaxis(results, 0, axis)
+    return results
 
 
 @dataclasses.dataclass

--- a/tests/test_numeric.py
+++ b/tests/test_numeric.py
@@ -24,14 +24,18 @@ def test_logsumexp_excluding_column_standard(shape, axis):
     the simple implementation is stable."""
     rng = np.random.default_rng(42)
 
-    if axis > len(shape):
+    if axis >= len(shape):
         return
 
     y = rng.normal(size=shape)
-    out = numeric.logsumexp_excluding_column(y)
-    exp = logsumexp_excluding_column_simple(y)
-
+    out = numeric.logsumexp_excluding_column(y, axis=axis)
+    exp = logsumexp_excluding_column_simple(y, axis=axis)
     npt.assert_allclose(out, exp, rtol=0.01, atol=1e-3)
+
+    # Check default for the `axis` argument
+    out2 = numeric.logsumexp_excluding_column(y)
+    exp2 = logsumexp_excluding_column_simple(y)
+    npt.assert_allclose(out2, exp2, rtol=0.01, atol=1e-3)
 
 
 def test_logsumexp_excluding_column_hard():

--- a/tests/test_numeric.py
+++ b/tests/test_numeric.py
@@ -1,0 +1,43 @@
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pytest
+from covvfit import numeric
+
+
+def logsumexp_excluding_column_simple(y, axis: int = -1):
+    # Numerical stability by shifting with max_val
+    max_val = jnp.max(y, axis=axis, keepdims=True)
+    shifted = y - max_val
+    # Compute sum exp shifted,
+    # Substract sum exp shifted for each column
+    # Take the log and add back the max_val
+    sum_exp_shifted = jnp.sum(jnp.exp(shifted), axis=axis, keepdims=True)
+    logsumexp_excl = jnp.log(sum_exp_shifted - jnp.exp(shifted)) + max_val
+    return logsumexp_excl
+
+
+@pytest.mark.parametrize("shape", [(2, 3, 5), (3,), (1, 3), (2, 4, 6)])
+@pytest.mark.parametrize("axis", [0, 1, 2, -1])
+def test_logsumexp_excluding_column_standard(shape, axis):
+    """Test on arrays of different shapes, but with entries for which
+    the simple implementation is stable."""
+    rng = np.random.default_rng(42)
+
+    if axis > len(shape):
+        return
+
+    y = rng.normal(size=shape)
+    out = numeric.logsumexp_excluding_column(y)
+    exp = logsumexp_excluding_column_simple(y)
+
+    npt.assert_allclose(out, exp, rtol=0.01, atol=1e-3)
+
+
+def test_logsumexp_excluding_column_hard():
+    """Test on examples where the simple implementation does not suffice."""
+    y = jnp.array([[1e8, 1.0, 1.0]])
+    out = numeric.logsumexp_excluding_column(y)
+    expected = jnp.array([[1 + jnp.log(2), 1e8, 1e8]])
+
+    npt.assert_allclose(out, expected)


### PR DESCRIPTION
Hi @dr-david,

Thanks for finding the bug! I have provided an implementation based on masking (similar to deconvolution with masking `log(0)` entries) and added the case you found as a test case, so that unit tests can catch it.