### PR TITLE
Make logit confidence bands faster

### DIFF
--- a/src/covvfit/_numeric.py
+++ b/src/covvfit/_numeric.py
@@ -1,4 +1,5 @@
 import dataclasses
+from functools import partial
 
 import jax
 import jax.numpy as jnp
@@ -44,7 +45,74 @@ def log1mexp(x: Float[Array, " *shape"]) -> Float[Array, " *shape"]:
     return jnp.where(x > -0.693, jnp.log(-jnp.expm1(x)), jnp.log1p(-jnp.exp(x)))
 
 
+def _log_cumulative_sum_exp_1d(x):
+    """Returns a 1D array 'out' where out[i] = logsumexp of x[:i+1]
+    (prefix sums in log-space)
+    """
+    neg_inf = jnp.finfo(x.dtype).min
+
+    def scan_fn(carry, current):
+        # carry = logsumexp so far, current = x[i]
+        new_carry = logsumexp(jnp.stack([carry, current]))
+        return new_carry, new_carry
+
+    init = neg_inf  # log(0)
+    _, out = jax.lax.scan(scan_fn, init, x)
+    return out
+
+
+@partial(jax.jit, static_argnames=["axis"])
 def logsumexp_excluding_column(
+    y: Float[Array, "*batch variants"],
+    axis: int = -1,
+) -> Float[Array, "*batch variants"]:
+    """
+    Compute logsumexp across the given axis for each element, excluding
+    the 'current' element at that axis index.
+
+    Args:
+        y: An array of shape [..., variants, ...].
+        axis: The axis along which we exclude each index before computing
+              logsumexp.
+
+    Returns:
+        An array of the same shape as `y`, whose element at index i along
+        `axis` is the log-sum-exp of all other entries (j != i).
+    """
+    neg_inf = jnp.finfo(y.dtype).min
+
+    # Move 'axis' to the last dimension for convenience
+    y = jnp.moveaxis(y, axis, -1)  # shape: [..., n]
+    *batch_dims, n = y.shape
+
+    # Flatten the leading dimensions so we can vmap over them
+    y_2d = y.reshape(-1, n)  # shape: (batch_size, n)
+
+    # Compute prefix and suffix log-cumulative-sums along the last dimension
+    prefix = jax.vmap(_log_cumulative_sum_exp_1d)(y_2d)
+    # suffix: reverse each row, compute prefix, then reverse result
+    suffix = jax.vmap(lambda row: jnp.flip(_log_cumulative_sum_exp_1d(jnp.flip(row))))(
+        y_2d
+    )
+    # Now:
+    #   prefix[i] = logsumexp( y[:i+1] )
+    #   suffix[i] = logsumexp( y[i:] )
+
+    # We want the log-sum-exp excluding y[i]. This is logsumexp( prefix[i-1], suffix[i+1] ).
+    # Handle boundary by padding prefix and suffix with -inf where needed.
+    prefix_left = jnp.pad(prefix[:, :-1], ((0, 0), (1, 0)), constant_values=neg_inf)
+    suffix_right = jnp.pad(suffix[:, 1:], ((0, 0), (0, 1)), constant_values=neg_inf)
+
+    # Combine along a new axis, then take logsumexp across that axis
+    out_2d = logsumexp(jnp.stack([prefix_left, suffix_right], axis=-1), axis=-1)
+    out = out_2d.reshape(*batch_dims, n)
+
+    # Move the excluded axis back to its original position
+    out = jnp.moveaxis(out, -1, axis)
+    return out
+
+
+def logsumexp_excluding_column_slow(
     y: Float[Array, "*batch variants"],
     axis: int = -1,
 ) -> Float[Array, "*batch variants"]:

--- a/src/covvfit/_quasimultinomial.py
+++ b/src/covvfit/_quasimultinomial.py
@@ -285,18 +285,16 @@ def get_confidence_bands_logit(
     ]
 
     logit_se = []
-    for i, ts in enumerate(ts):
-        # Compute the Jacobian of the transformation and project standard errors
-        def _aux(t):
-            jacobian = jax.jacobian(_create_logit_predictions_fn(n_variants, i, t))(
-                theta
-            )
-            standard_errors = get_standard_errors(
-                jacobian=jacobian, covariance=covariance
-            )
-            return standard_errors
 
-        se = jax.vmap(_aux)(ts)
+    # Compute the Jacobian of the transformation and project standard errors
+    @jax.jit
+    def _aux(i: int, t):
+        jacobian = jax.jacobian(_create_logit_predictions_fn(n_variants, i, t))(theta)
+        standard_errors = get_standard_errors(jacobian=jacobian, covariance=covariance)
+        return standard_errors
+
+    for i, ts in enumerate(ts):
+        se = jax.vmap(lambda t: _aux(i, t))(ts)
         logit_se.append(se)
 
     # Compute confidence intervals on the logit scale

--- a/tests/test_numeric.py
+++ b/tests/test_numeric.py
@@ -24,7 +24,7 @@ def test_logsumexp_excluding_column_standard(shape, axis):
     the simple implementation is stable."""
     rng = np.random.default_rng(42)
 
-    if axis >= len(shape):
+    if axis >= len(shape) or shape[axis] == 1:
         return
 
     y = rng.normal(size=shape)


### PR DESCRIPTION
This PR improves the efficiency of the confidence bands calculation. It does this by the following:

  - First, the Jacobian for the delta method can be calculated for a single timepoint at a time, rather than for all the timepoints (what results in a large matrix with many zero entries). This limits both the required memory and the time and results in a large speedup.
  - Second, the calculation of logits is now faster, as we don't use masking approach (which requires $O(V^2)$ operations per a single timepoint, where $V$ is the number of variants), but rather an approach employing prefixes and suffixes (which requires $O(V)$ operations per a single timepoint). (Note that this $O(V^2)$ factor was acquired during #55 , which replaced a numerically unstable implementation working in $O(V)$ time. Now we are back to $O(V)$ time, but in a numerically stable manner! :slightly_smiling_face: )
  - Finally, some functions are now JITted, to make them faster. 