### PR TITLE
Minor adjustments to the plots

### DIFF
--- a/src/covvfit/_cli/infer.py
+++ b/src/covvfit/_cli/infer.py
@@ -329,14 +329,27 @@ def infer(
         theta_star, standard_errors_estimates, confidence_level=0.95
     )
 
-    pprint("\n\nRelative growth advantages:")
+    pprint("\n\nRelative growth advantages (per day):")
     for variant, m, low, up in zip(
         variants_effective[1:],
         qm.get_relative_growths(theta_star, n_variants=n_variants_effective),
         qm.get_relative_growths(confints_estimates[0], n_variants=n_variants_effective),
         qm.get_relative_growths(confints_estimates[1], n_variants=n_variants_effective),
     ):
-        pprint(f"  {variant}: {float(m):.2f} ({float(low):.2f} – {float(up):.2f})")
+        pprint(
+            f"  {variant}: {float(m)/ time_scaler.time_unit :.4f} ({float(low) / time_scaler.time_unit:.4f} – {float(up) / time_scaler.time_unit :.4f})"
+        )
+
+    pprint("\n\nRelative growth advantages (per week):")
+    for variant, m, low, up in zip(
+        variants_effective[1:],
+        qm.get_relative_growths(theta_star, n_variants=n_variants_effective),
+        qm.get_relative_growths(confints_estimates[0], n_variants=n_variants_effective),
+        qm.get_relative_growths(confints_estimates[1], n_variants=n_variants_effective),
+    ):
+        pprint(
+            f"  {variant}: {DAYS_IN_A_WEEK * float(m)/ time_scaler.time_unit :.4f} ({DAYS_IN_A_WEEK * float(low) / time_scaler.time_unit:.4f} – {DAYS_IN_A_WEEK * float(up) / time_scaler.time_unit :.4f})"
+        )
 
     # Generate predictions
     ys_fitted_confint = qm.get_confidence_bands_logit(
@@ -378,6 +391,7 @@ def infer(
         bottom=plot_dimensions.bottom,
         left=plot_dimensions.left,
         right=plot_dimensions.right,
+        sharex=True,
     )
 
     def plot_city(ax, i: int) -> None:

--- a/src/covvfit/_cli/infer.py
+++ b/src/covvfit/_cli/infer.py
@@ -1,4 +1,5 @@
 """Script running Covvfit inference on the data."""
+import warnings
 from pathlib import Path
 from typing import Annotated, NamedTuple, Optional
 
@@ -246,9 +247,23 @@ def infer(
         Optional[str],
         typer.Option("--matplotlib-backend", help="Matplotlib backend to use"),
     ] = None,
+    overwrite_output: Annotated[
+        bool,
+        typer.Option(
+            "--overwrite-output",
+            help="Allows overwriting the output directory, if it already exists. Note: this may result in unintented loss of data.",
+        ),
+    ] = False,
 ) -> None:
     """Runs growth advantage inference."""
     _set_matplotlib_backend(matplotlib_backend)
+
+    # Ignore warnings with JAX converting arrays from 64-bit to 32-bit
+    warnings.filterwarnings(
+        "ignore",
+        message=r"Explicitly requested dtype float64 requested in zeros.*",
+        category=UserWarning,
+    )
 
     if var is None and config is None:
         raise ValueError(
@@ -274,7 +289,7 @@ def infer(
     )
 
     output = Path(output)
-    output.mkdir(parents=True, exist_ok=False)
+    output.mkdir(parents=True, exist_ok=overwrite_output)
 
     def pprint(message):
         with open(output / "log.txt", "a") as file:

--- a/src/covvfit/plotting/_timeseries.py
+++ b/src/covvfit/plotting/_timeseries.py
@@ -31,9 +31,9 @@ COLORS_COVSPECTRUM: dict[Variant, Color] = {
     "BA.2.86": "#FF20E0",
     # TODO(Pawel, David): Use consistent colors with Covspectrum
     "JN.1": "#00e9ff",  # improv
-    "KP.2": "#D16666",  # improv
-    "KP.3": "#66A366",  # improv
-    "XEC": "#A366A3",  # improv
+    "KP.2": "#876566",
+    "KP.3": "#331eee",
+    "XEC": "#a2a626",
     "undetermined": "#969696",
 }
 
@@ -119,7 +119,7 @@ class _MonthStartLocator(ticker.Locator):
             ticks.append(offset_days)
             current += pd.offsets.MonthBegin(1)
 
-        return ticks
+        return ticks[::3]
 
     def tick_values(self, vmin, vmax):
         # Matplotlib may call tick_values directly; just reuse __call__()
@@ -131,7 +131,7 @@ class AdjustXAxisForTime:
         self,
         time0: str,
         *,
-        fmt="%b. '%y",
+        fmt="%b '%y",
         time_unit: str = "D",
     ) -> None:
         """Adjusts the X ticks, so that the ticks
@@ -308,4 +308,5 @@ def plot_confidence_bands(
             alpha=alpha,
             label=label,
             **kwargs,
+            edgecolor=None,
         )


### PR DESCRIPTION
This PR makes the minor adjustments to the `covvfit infer` tool:

  - Allow selecting the timescale (in months) between ticks on the time axis.
  - Estimate growth rates in days and weeks.
  - Allow overwriting the output directory (useful for debugging purposes, although generally one should be cautious with this. By default it is disabled to make everybody safer).
  - Use the official colour scheme for new variants.