### PR TITLE
Second implementation of the Pearson's residuals

### DIFF
--- a/src/covvfit/_cli/infer.py
+++ b/src/covvfit/_cli/infer.py
@@ -254,12 +254,12 @@ def infer(
             help="Allows overwriting the output directory, if it already exists. Note: this may result in unintented loss of data.",
         ),
     ] = False,
-    residuals_simple: Annotated[
+    residuals_p1mp: Annotated[
         bool,
         typer.Option(
-            "--residuals-simple",
-            help="If True, to calculate the overdispersion we will use `p_i` in the denominator."
-            "If False (default), we use `p_i(1 - p_i)`.",
+            "--residuals-p1mp",
+            help="If True, to calculate the overdispersion we will use `p_i(1-p_i)` in the denominator."
+            "If False (default), we use `p_i` in the denominator.",
         ),
     ] = False,
 ) -> None:
@@ -362,7 +362,7 @@ def infer(
     overdispersion_tuple = qm.compute_overdispersion(
         observed=ys_effective,
         predicted=ys_fitted,
-        p1mp=not residuals_simple,
+        p1mp=residuals_p1mp,
     )
 
     overdisp_fixed = overdispersion_tuple.overall

--- a/src/covvfit/_cli/infer.py
+++ b/src/covvfit/_cli/infer.py
@@ -254,6 +254,13 @@ def infer(
             help="Allows overwriting the output directory, if it already exists. Note: this may result in unintented loss of data.",
         ),
     ] = False,
+    p1mp: Annotated[
+        bool,
+        typer.Option(
+            "--residuals-variance",
+            help="Whether to use p(1-p) to calculate the overdispersion. If False, just p will be used.",
+        ),
+    ] = False,
 ) -> None:
     """Runs growth advantage inference."""
     _set_matplotlib_backend(matplotlib_backend)
@@ -354,6 +361,7 @@ def infer(
     overdispersion_tuple = qm.compute_overdispersion(
         observed=ys_effective,
         predicted=ys_fitted,
+        p1mp=p1mp,
     )
 
     overdisp_fixed = overdispersion_tuple.overall

--- a/src/covvfit/_cli/infer.py
+++ b/src/covvfit/_cli/infer.py
@@ -254,11 +254,12 @@ def infer(
             help="Allows overwriting the output directory, if it already exists. Note: this may result in unintented loss of data.",
         ),
     ] = False,
-    p1mp: Annotated[
+    residuals_simple: Annotated[
         bool,
         typer.Option(
-            "--residuals-variance",
-            help="Whether to use p(1-p) to calculate the overdispersion. If False, just p will be used.",
+            "--residuals-simple",
+            help="If True, to calculate the overdispersion we will use `p_i` in the denominator."
+            "If False (default), we use `p_i(1 - p_i)`.",
         ),
     ] = False,
 ) -> None:
@@ -361,7 +362,7 @@ def infer(
     overdispersion_tuple = qm.compute_overdispersion(
         observed=ys_effective,
         predicted=ys_fitted,
-        p1mp=p1mp,
+        p1mp=not residuals_simple,
     )
 
     overdisp_fixed = overdispersion_tuple.overall

--- a/src/covvfit/_cli/infer.py
+++ b/src/covvfit/_cli/infer.py
@@ -481,7 +481,15 @@ def infer(
     df_final = df_diffs.merge(df_lower, on=["Variant", "Reference_Variant"]).merge(
         df_upper, on=["Variant", "Reference_Variant"]
     )
-    df_final.to_csv(output / "pairwise_fitnesses.csv")
+    df_final.to_csv(output / "pairwise_fitnesses.csv", sep=data_separator, index=False)
+
+    pprint("\n\nRelative fitness values:")
+    for _, row in df_final.iterrows():
+        if row["Variant"] == row["Reference_Variant"]:
+            continue
+        pprint(
+            f"  {row['Variant']} / {row['Reference_Variant']}:\t{row['Estimate']:.3f} ({row['Lower_CI']:.3f} – {row['Upper_CI']:.3f})"
+        )
 
     # Create a plot
     colors = [config.plot.variant_colors[var] for var in variants_investigated]

--- a/src/covvfit/_quasimultinomial.py
+++ b/src/covvfit/_quasimultinomial.py
@@ -732,7 +732,7 @@ def compute_alleged_squared_pearson_residuals(
     observed: list[Float[Array, "timepoints variants"]],
     predicted: list[Float[Array, "timepoints variants"]],
     sample_sizes: _OverDispersionType = 1.0,
-    p1mp: bool = True,
+    p1mp: bool = False,
 ) -> list[Float[Array, "timepoints variants"]]:
     n_cities = len(observed)
     if len(predicted) != n_cities:
@@ -774,7 +774,7 @@ def compute_overdispersion(
     predicted: list[Float[Array, "timepoints variants"]],
     sample_sizes: _OverDispersionType = 1.0,
     epsilon: float = 0.001,
-    p1mp: bool = True,
+    p1mp: bool = False,
 ) -> OverDispersion:
     """
     Compute overdispersion from a quasimultinomial model.

--- a/src/covvfit/_quasimultinomial.py
+++ b/src/covvfit/_quasimultinomial.py
@@ -732,6 +732,7 @@ def compute_alleged_squared_pearson_residuals(
     observed: list[Float[Array, "timepoints variants"]],
     predicted: list[Float[Array, "timepoints variants"]],
     sample_sizes: _OverDispersionType = 1.0,
+    p1mp: bool = True,
 ) -> list[Float[Array, "timepoints variants"]]:
     n_cities = len(observed)
     if len(predicted) != n_cities:
@@ -751,10 +752,16 @@ def compute_alleged_squared_pearson_residuals(
     sample_sizes = [array[:length] for array, length in zip(ns_array, lengths)]
     # Now sample_sizes has the same number of timepoints as predicted and observed
 
-    return [
-        ns[:, None] * jnp.square(obs - pre) / (pre * (1 - pre))
-        for obs, pre, ns in zip(observed, predicted, sample_sizes)
-    ]
+    if p1mp:  # Use p(1-p) in the denominator
+        return [
+            ns[:, None] * jnp.square(obs - pre) / (pre * (1 - pre))
+            for obs, pre, ns in zip(observed, predicted, sample_sizes)
+        ]
+    else:  # Use p in the denominator
+        return [
+            ns[:, None] * jnp.square(obs - pre) / pre
+            for obs, pre, ns in zip(observed, predicted, sample_sizes)
+        ]
 
 
 class OverDispersion(NamedTuple):
@@ -767,6 +774,7 @@ def compute_overdispersion(
     predicted: list[Float[Array, "timepoints variants"]],
     sample_sizes: _OverDispersionType = 1.0,
     epsilon: float = 0.001,
+    p1mp: bool = True,
 ) -> OverDispersion:
     """
     Compute overdispersion from a quasimultinomial model.
@@ -787,6 +795,7 @@ def compute_overdispersion(
         observed=observed,
         predicted=predicted,
         sample_sizes=sample_sizes,
+        p1mp=p1mp,
     )
     n_cities = len(observed)
     n_variants = observed[0].shape[1]


### PR DESCRIPTION
In [*Bayesian Nonparametric Quasi-Likelihood*](https://arxiv.org/abs/2405.20601) it is proposed to use 

$$R_1 = \sum_i (y_i-\mu_i)^2 / \mu_i$$

for a residual, rather than

$$R_2 = \sum_i (y_i - \mu_i)^2 / ( \mu_i (1-\mu_i) )$$

we are using to calculate the overdispersion factor. (There is also a slight difference in the denominator, resulting in a different way to calculate the degrees of freedom. And we do also outlier removal step.)

For $K=2$ variants, it holds that $R_1 = R_2$ are the usual Pearson's residuals.

I tested some settings with $K=3$ and it seems that $R_2 > R_1$, where the ratio seemed to be between 1.5 and 2 (disclaimer: I did not test it very thoroughly, but rather checked some values of $y$ and $\mu$).

In this PR I approached implementing the formula for $R_1$, rather than $R_2$ and on some real data set the inferences were very similar. However, maybe we should consider making this choice explicit and controlled by a flag.
