### PR TITLE
deps: Adding Dependabot config for automatic version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# This file configures Dependabot for a Python project using pip.
+# It specifies that Dependabot should check for updates to Python packages
+# in the root directory of the project on a weekly basis.
+# It also configures Dependabot to check for updates to GitHub Actions
+
+
+version: 2
+updates:
+  - package-ecosystem: "pip" 
+    directory: "/" 
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds a simple config to configure [Dependabot Version Updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) across _Virus Repos_. 

With covvfit soon to be integrated into the regular surveillance, I took the liberty to already make the config. 

Upon merge to `main` we still have to enable by:
- [ ] check Repo Settings >> Security... >> Dependabot Version Updates

This will then enable Dependabot.  PRs will be opened automatically if either `python/poetry` dependencies or `github-actions` receive new versions. 

Keeping covvfit's dependencies up-to-date as much as the `pyproject.toml` restrictions allow. 

____

_(Context: V-Pipe CI suddenly started failing because of outdated `github-actions`, which lead us to decide for automatic updates)_