### PR TITLE
Change package version for building documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ black = "==23.12.1"
 pre-commit = "^4.2.0"
 pyright = "^1.1.333"
 mkdocs-material = "^9.5.50"
-mkdocstrings = {extras = ["python-legacy"], version = "^0.28.3"}
+mkdocstrings = {extras = ["python-legacy"], version = "^0.21.2,<0.28"}
 mkdocs = "^1.5.3"
 mkdocs-autorefs = "^1.4.0"
 jupytext = "^1.16.1"


### PR DESCRIPTION
It seems that one of the dependabot changes broke the documentation building pipeline, so that the documentation is no longer automatically built and deployed. This PR tries to fix the dependencies.