### PR TITLE
Beta binomial deconvolution

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -30,3 +30,8 @@ The API is available [here](plotting.md).
 
 General numerical programming utilities.
 The API is available [here](numeric.md).
+
+## Variant beta-binomial
+
+Utilities for the new multi-city variant beta-binomial feature.
+The API is available [here](variant_beta_binomial.md).

--- a/docs/api/variant_beta_binomial.md
+++ b/docs/api/variant_beta_binomial.md
@@ -1,0 +1,15 @@
+# Variant Beta-Binomial
+
+Multi-city beta-binomial utilities for variant competition inference.
+
+Import low-level modules from `covvfit` package internals.
+
+::: covvfit._variant_beta_binomial.data.ModelData
+
+::: covvfit._variant_beta_binomial.data.DispersionParams
+
+::: covvfit._variant_beta_binomial.growth.LinearGrowthParams
+
+::: covvfit._variant_beta_binomial.model.model_loglik
+
+::: covvfit._variant_beta_binomial.numpyro_model.numpyro_model_hierarchical

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,8 @@ $ covvfit check
 
 For an example **how to analyze the data** using the provided command line tool, see [this tutorial](./cli.md).
 
+For an end-to-end hierarchical Bayesian example of the new variant beta-binomial model, see [this guide](./variant_beta_binomial_example.md).
+
 For more detailed installation instructions, including troubleshooting, see the [installation guide](./installation.md).
 
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -57,3 +57,8 @@ As both $y_k(t)$ and $p_k(t)$ are probability vectors, we use the quasi-multinom
 $$ q(f,b)= \sum_{k=1}^K \sum_{t=1}^T\sum_{v=1}^V y_{vk}(t) \log p_{vk}(t). $$ 
 
 We numerically optimize it to find the maximum quasi-likelihood estimate $\hat \theta = (\hat f, \hat b)$.
+
+## Beta-binomial extension (additive)
+
+The repository now also includes an additive multi-city variant beta-binomial feature implemented in dedicated modules.  
+It does not modify the existing quasi-multinomial deconvolution behavior in `covvfit._deconvolution`, and can be adopted independently.

--- a/docs/variant_beta_binomial_example.md
+++ b/docs/variant_beta_binomial_example.md
@@ -2,6 +2,8 @@
 
 This page explains how to run the end-to-end hierarchical Bayesian demo for the new variant beta-binomial model.
 
+For detailed practical VI recommendations (guide choice, tuning, and failure-mode debugging), see the [VI guidelines](./variational_inference_guidelines.md).
+
 The script is:
 
 - `examples/variant_beta_binomial_hierarchical_bayes.py`
@@ -9,7 +11,9 @@ The script is:
 It does four things in one run:
 
 1. Simulates multi-city beta-binomial count data from known ground truth.
-2. Fits a hierarchical Bayesian model with NumPyro (NUTS).
+2. Fits a hierarchical Bayesian model using either:
+   - HMC (`NUTS`), or
+   - variational inference (`SVI` with NumPyro autoguides).
 3. Prints MCMC diagnostics (`n_eff`, `r_hat`, divergences).
 4. Prints recovery summary comparing posterior slopes with the true slopes.
 5. Saves posterior predictive plots with uncertainty bands.
@@ -32,6 +36,51 @@ Use recovery-friendly defaults:
 python examples/variant_beta_binomial_hierarchical_bayes.py
 ```
 
+This uses `--inference-method hmc` by default.
+
+## Dramatic Emergence Scenario (3 Variants)
+
+To simulate sharp logistic takeover dynamics (one early dominant variant, then two emergent variants, with one becoming dominant), run:
+
+```bash
+python examples/variant_beta_binomial_hierarchical_bayes.py \
+  --scenario dramatic_emergence \
+  --inference-method hmc \
+  --n-samples 240 \
+  --coverage 400 \
+  --time-max 12 \
+  --warmup 700 \
+  --samples 700 \
+  --output-dir generated/variant_beta_binomial_dramatic
+```
+
+## Run with VI
+
+```bash
+python examples/variant_beta_binomial_hierarchical_bayes.py \
+  --inference-method svi \
+  --svi-steps 8000 \
+  --svi-lr 0.01 \
+  --svi-guide lowrank \
+  --svi-rank 8 \
+  --svi-restarts 3 \
+  --samples 1000
+```
+
+Flow-based NumPyro autoguide example (no extra dependencies):
+
+```bash
+python examples/variant_beta_binomial_hierarchical_bayes.py \
+  --inference-method svi \
+  --svi-guide bnaf \
+  --svi-num-flows 2 \
+  --svi-bnaf-hidden-factors 8,8 \
+  --svi-lr 0.001 \
+  --svi-steps 10000 \
+  --svi-restarts 3 \
+  --samples 1000
+```
+
 By default, plots are saved to:
 
 - `generated/variant_beta_binomial_demo/abundance_curves_by_city.png`
@@ -44,6 +93,7 @@ You can override the simulation and inference settings from CLI:
 ```bash
 python examples/variant_beta_binomial_hierarchical_bayes.py \
   --seed 1 \
+  --inference-method hmc \
   --n-samples 240 \
   --coverage 400 \
   --time-max 14 \
@@ -57,15 +107,26 @@ python examples/variant_beta_binomial_hierarchical_bayes.py \
 Available options:
 
 - `--seed`: random seed
+- `--scenario`: `baseline` or `dramatic_emergence`
+- `--inference-method`: `hmc` or `svi`
 - `--n-samples`: total simulated samples
 - `--coverage`: per-locus read depth
 - `--time-max`: maximum time used in simulation
+- `--warmup`: NUTS warmup steps (HMC only)
+- `--target-accept-prob`: NUTS target acceptance probability (HMC only)
+- `--svi-steps`: optimization steps for SVI
+- `--svi-lr`: learning rate for SVI
+- `--svi-guide`: `lowrank` (default), `autonormal`, `iaf`, or `bnaf` (all NumPyro autoguides)
+- `--svi-rank`: rank for low-rank guide
+- `--svi-num-flows`: number of flow transforms for `iaf`/`bnaf`
+- `--svi-iaf-hidden-dims`: comma-separated hidden dimensions for `iaf` (e.g. `128,128`)
+- `--svi-bnaf-hidden-factors`: comma-separated hidden factors for `bnaf` (e.g. `8,8`)
+- `--svi-restarts`: number of SVI restarts; best ELBO run is used
+- `--samples`: posterior draws (HMC samples or SVI guide posterior samples)
 - `--output-dir`: output directory for generated plots
 - `--n-grid`: number of time points for smooth predictive curves
 - `--predictive-coverage`: read depth used for simulated observed-frequency bands
 - `--predictive-draws`: number of posterior predictive draws for smoother observed-frequency bands
-- `--warmup`: NUTS warmup steps
-- `--samples`: posterior draws
 - `--show-plots`: display plots interactively after saving
 
 ## What to Look At in the Output
@@ -77,6 +138,9 @@ Focus on:
 - `Recovery summary (slopes)`:
   - `Posterior mean slopes` should be close to `True slopes`
   - `Truth in 90% interval` should ideally be all `True`
+- Inference-specific summary:
+  - HMC: check divergences and effective sample diagnostics
+  - SVI: check optimization loss (`initial_loss` to `final_loss`) and selected restart
 - Generated figures:
   - abundance plots per city: posterior median + 90% band + ground truth
   - mutation plots per city/locus:
@@ -90,3 +154,6 @@ Focus on:
 - Runs are stochastic. Different seeds can give slightly different posterior summaries.
 - If observed-frequency bands look jagged, increase `--predictive-draws`.
 - If recovery is unstable, increase `--n-samples`, `--coverage`, and/or MCMC budget (`--warmup`, `--samples`).
+- This demo intentionally uses only NumPyro autoguides for VI; no FlowJAX dependency is required.
+- For flow guides, `bnaf` is currently more numerically stable in this demo than `iaf`.
+- For `iaf`, hidden dimensions must be large enough for the latent dimension (if you see an input-dimension error, increase `--svi-iaf-hidden-dims`).

--- a/docs/variant_beta_binomial_example.md
+++ b/docs/variant_beta_binomial_example.md
@@ -1,0 +1,70 @@
+# Hierarchical Bayesian Example
+
+This page explains how to run the end-to-end hierarchical Bayesian demo for the new variant beta-binomial model.
+
+The script is:
+
+- `examples/variant_beta_binomial_hierarchical_bayes.py`
+
+It does four things in one run:
+
+1. Simulates multi-city beta-binomial count data from known ground truth.
+2. Fits a hierarchical Bayesian model with NumPyro (NUTS).
+3. Prints MCMC diagnostics (`n_eff`, `r_hat`, divergences).
+4. Prints recovery summary comparing posterior slopes with the true slopes.
+
+## Prerequisites
+
+From the repository root:
+
+```bash
+micromamba activate covvfit
+```
+
+If this is your first run in the environment, ensure dependencies are installed (`numpyro`, `jax`, etc.).
+
+## Quick Run
+
+Use recovery-friendly defaults:
+
+```bash
+python examples/variant_beta_binomial_hierarchical_bayes.py
+```
+
+## Custom Run
+
+You can override the simulation and inference settings from CLI:
+
+```bash
+python examples/variant_beta_binomial_hierarchical_bayes.py \
+  --seed 1 \
+  --n-samples 240 \
+  --coverage 400 \
+  --time-max 14 \
+  --warmup 900 \
+  --samples 900
+```
+
+Available options:
+
+- `--seed`: random seed
+- `--n-samples`: total simulated samples
+- `--coverage`: per-locus read depth
+- `--time-max`: maximum time used in simulation
+- `--warmup`: NUTS warmup steps
+- `--samples`: posterior draws
+
+## What to Look At in the Output
+
+Focus on:
+
+- `Number of divergences`: target is `0`
+- `r_hat`: should be close to `1.00`
+- `Recovery summary (slopes)`:
+  - `Posterior mean slopes` should be close to `True slopes`
+  - `Truth in 90% interval` should ideally be all `True`
+
+## Notes
+
+- Runs are stochastic. Different seeds can give slightly different posterior summaries.
+- If recovery is unstable, increase `--n-samples`, `--coverage`, and/or MCMC budget (`--warmup`, `--samples`).

--- a/docs/variant_beta_binomial_example.md
+++ b/docs/variant_beta_binomial_example.md
@@ -12,6 +12,7 @@ It does four things in one run:
 2. Fits a hierarchical Bayesian model with NumPyro (NUTS).
 3. Prints MCMC diagnostics (`n_eff`, `r_hat`, divergences).
 4. Prints recovery summary comparing posterior slopes with the true slopes.
+5. Saves posterior predictive plots with uncertainty bands.
 
 ## Prerequisites
 
@@ -31,6 +32,11 @@ Use recovery-friendly defaults:
 python examples/variant_beta_binomial_hierarchical_bayes.py
 ```
 
+By default, plots are saved to:
+
+- `generated/variant_beta_binomial_demo/abundance_curves_by_city.png`
+- `generated/variant_beta_binomial_demo/mutation_predictions_by_city_locus.png`
+
 ## Custom Run
 
 You can override the simulation and inference settings from CLI:
@@ -41,6 +47,9 @@ python examples/variant_beta_binomial_hierarchical_bayes.py \
   --n-samples 240 \
   --coverage 400 \
   --time-max 14 \
+  --output-dir generated/variant_beta_binomial_custom \
+  --n-grid 250 \
+  --predictive-draws 6000 \
   --warmup 900 \
   --samples 900
 ```
@@ -51,8 +60,13 @@ Available options:
 - `--n-samples`: total simulated samples
 - `--coverage`: per-locus read depth
 - `--time-max`: maximum time used in simulation
+- `--output-dir`: output directory for generated plots
+- `--n-grid`: number of time points for smooth predictive curves
+- `--predictive-coverage`: read depth used for simulated observed-frequency bands
+- `--predictive-draws`: number of posterior predictive draws for smoother observed-frequency bands
 - `--warmup`: NUTS warmup steps
 - `--samples`: posterior draws
+- `--show-plots`: display plots interactively after saving
 
 ## What to Look At in the Output
 
@@ -63,8 +77,16 @@ Focus on:
 - `Recovery summary (slopes)`:
   - `Posterior mean slopes` should be close to `True slopes`
   - `Truth in 90% interval` should ideally be all `True`
+- Generated figures:
+  - abundance plots per city: posterior median + 90% band + ground truth
+  - mutation plots per city/locus:
+    - observed points (`Y/N`)
+    - latent mutation band (`mu`)
+    - observed-frequency posterior predictive band (simulated `Y/N`)
+    - ground truth
 
 ## Notes
 
 - Runs are stochastic. Different seeds can give slightly different posterior summaries.
+- If observed-frequency bands look jagged, increase `--predictive-draws`.
 - If recovery is unstable, increase `--n-samples`, `--coverage`, and/or MCMC budget (`--warmup`, `--samples`).

--- a/examples/variant_beta_binomial_demo.py
+++ b/examples/variant_beta_binomial_demo.py
@@ -1,0 +1,68 @@
+"""Minimal end-to-end demo for variant beta-binomial model."""
+
+import jax
+import jax.numpy as jnp
+from covvfit._variant_beta_binomial.growth import LinearGrowthParams
+from covvfit._variant_beta_binomial.model import model_loglik
+from covvfit._variant_beta_binomial.simulate import simulate_dataset
+
+
+def main() -> None:
+    key = jax.random.PRNGKey(0)
+
+    C = 3
+    G = 6
+    N_samples = 60
+
+    city = jnp.repeat(jnp.arange(C, dtype=jnp.int32), N_samples // C)
+    time = jnp.tile(jnp.linspace(0.0, 10.0, N_samples // C), C)
+
+    intercepts = jnp.array(
+        [
+            [0.0, 1.2, -0.6, 0.3],
+            [0.3, 0.9, -0.2, -0.4],
+            [-0.2, 0.7, 0.5, -0.1],
+        ]
+    )
+    slopes = jnp.array([0.04, -0.02, 0.03, 0.01])
+    growth = LinearGrowthParams(intercepts=intercepts, slopes=slopes)
+
+    A = jnp.array(
+        [
+            [1, 0, 1, 0, 1, 0],
+            [0, 1, 1, 0, 0, 1],
+            [1, 1, 0, 1, 0, 0],
+            [0, 0, 1, 1, 1, 1],
+        ],
+        dtype=bool,
+    )
+
+    coverage = jnp.full((N_samples, G), 100, dtype=jnp.int32)
+    eta_rho = jnp.array([-0.2, 0.1, 0.0, -0.4, 0.2, -0.1])
+
+    result = simulate_dataset(
+        key=key,
+        A=A,
+        growth_params=growth,
+        eta_rho=eta_rho,
+        city=city,
+        time=time,
+        coverage=coverage,
+        mask_probability=0.1,
+    )
+
+    ll = model_loglik(
+        growth_params=result.growth_params,
+        dispersion_params=result.dispersion_params,
+        data=result.data,
+    )
+
+    print("log_pi.shape:", result.log_pi.shape)
+    print("mu.shape:", result.mu.shape)
+    print("Y.shape:", result.data.Y.shape)
+    print("N.shape:", result.data.N.shape)
+    print("total_loglik:", float(ll))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/variant_beta_binomial_hierarchical_bayes.py
+++ b/examples/variant_beta_binomial_hierarchical_bayes.py
@@ -1,0 +1,152 @@
+"""End-to-end hierarchical Bayesian inference demo for variant beta-binomial model."""
+
+import argparse
+
+import jax
+import jax.numpy as jnp
+from covvfit._variant_beta_binomial.growth import LinearGrowthParams
+from covvfit._variant_beta_binomial.numpyro_model import numpyro_model_hierarchical
+from covvfit._variant_beta_binomial.simulate import simulate_dataset
+from numpyro.infer import MCMC, NUTS
+
+
+def run_demo(
+    seed: int = 0,
+    n_samples: int = 180,
+    coverage_n: int = 300,
+    time_max: float = 12.0,
+    num_warmup: int = 700,
+    num_posterior_samples: int = 700,
+) -> None:
+    key = jax.random.PRNGKey(seed)
+    key_sim, key_mcmc = jax.random.split(key)
+
+    C = 3
+    G = 6
+    city = jnp.repeat(jnp.arange(C, dtype=jnp.int32), n_samples // C)
+    time = jnp.tile(jnp.linspace(0.0, time_max, n_samples // C), C)
+
+    true_intercepts = jnp.array(
+        [
+            [0.0, 0.7, -0.2, 0.1],
+            [0.0, 0.5, 0.1, -0.3],
+            [0.0, 0.8, 0.3, -0.1],
+        ],
+        dtype=float,
+    )
+    true_slopes = jnp.array([0.0, 0.05, -0.02, 0.03], dtype=float)
+
+    growth_true = LinearGrowthParams(intercepts=true_intercepts, slopes=true_slopes)
+
+    A = jnp.array(
+        [
+            [1, 0, 1, 0, 1, 0],
+            [0, 1, 1, 0, 0, 1],
+            [1, 1, 0, 1, 0, 0],
+            [0, 0, 1, 1, 1, 1],
+        ],
+        dtype=bool,
+    )
+    coverage = jnp.full((n_samples, G), coverage_n, dtype=jnp.int32)
+    true_eta_rho = jnp.array([-0.3, -0.1, 0.2, -0.4, 0.1, 0.0], dtype=float)
+
+    sim = simulate_dataset(
+        key=key_sim,
+        A=A,
+        growth_params=growth_true,
+        eta_rho=true_eta_rho,
+        city=city,
+        time=time,
+        coverage=coverage,
+        mask_probability=0.1,
+    )
+
+    nuts = NUTS(numpyro_model_hierarchical, target_accept_prob=0.95)
+    mcmc = MCMC(
+        nuts,
+        num_warmup=num_warmup,
+        num_samples=num_posterior_samples,
+        num_chains=1,
+        progress_bar=False,
+    )
+    mcmc.run(key_mcmc, data=sim.data, n_cities=C)
+    mcmc.print_summary(exclude_deterministic=False)
+
+    posterior = mcmc.get_samples()
+    slope_loc = posterior["slope_loc"]
+    slope_scale = posterior["slope_scale"]
+    slope_raw = posterior["slope_raw"]
+
+    slopes_rel = slope_loc[:, None] + slope_scale[:, None] * slope_raw
+    slopes = jnp.concatenate([jnp.zeros((slopes_rel.shape[0], 1)), slopes_rel], axis=1)
+
+    slopes_post_mean = jnp.mean(slopes, axis=0)
+    slopes_q05 = jnp.quantile(slopes, 0.05, axis=0)
+    slopes_q95 = jnp.quantile(slopes, 0.95, axis=0)
+    slopes_cover = (true_slopes >= slopes_q05) & (true_slopes <= slopes_q95)
+
+    print("\nRecovery summary (slopes):")
+    print("True slopes:", true_slopes)
+    print("Posterior mean slopes:", slopes_post_mean)
+    print("Posterior 90% lower:", slopes_q05)
+    print("Posterior 90% upper:", slopes_q95)
+    print("Truth in 90% interval:", slopes_cover)
+    print("Abs. error slopes:", jnp.abs(slopes_post_mean - true_slopes))
+    eta_loc_post = posterior["eta_loc"]
+    print(
+        "Posterior eta_loc mean (true mean eta_rho):",
+        float(jnp.mean(eta_loc_post)),
+        "(",
+        float(jnp.mean(true_eta_rho)),
+        ")",
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run hierarchical Bayesian inference demo for variant beta-binomial model."
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Random seed.")
+    parser.add_argument(
+        "--n-samples",
+        type=int,
+        default=180,
+        help="Total number of simulated samples (should be divisible by number of cities).",
+    )
+    parser.add_argument(
+        "--coverage",
+        type=int,
+        default=300,
+        help="Per-sample per-locus sequencing coverage.",
+    )
+    parser.add_argument(
+        "--time-max",
+        type=float,
+        default=12.0,
+        help="Maximum simulation time.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=700,
+        help="Number of NUTS warmup steps.",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=700,
+        help="Number of posterior samples.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    run_demo(
+        seed=args.seed,
+        n_samples=args.n_samples,
+        coverage_n=args.coverage,
+        time_max=args.time_max,
+        num_warmup=args.warmup,
+        num_posterior_samples=args.samples,
+    )

--- a/examples/variant_beta_binomial_hierarchical_bayes.py
+++ b/examples/variant_beta_binomial_hierarchical_bayes.py
@@ -1,13 +1,257 @@
 """End-to-end hierarchical Bayesian inference demo for variant beta-binomial model."""
 
 import argparse
+from pathlib import Path
 
 import jax
 import jax.numpy as jnp
+import matplotlib.pyplot as plt
+from covvfit._variant_beta_binomial.dispersion import (
+    rho_to_log_kappa,
+    transform_eta_to_rho,
+)
 from covvfit._variant_beta_binomial.growth import LinearGrowthParams
 from covvfit._variant_beta_binomial.numpyro_model import numpyro_model_hierarchical
 from covvfit._variant_beta_binomial.simulate import simulate_dataset
 from numpyro.infer import MCMC, NUTS
+
+
+def _prepend_reference(x_rel: jax.Array) -> jax.Array:
+    if x_rel.ndim == 2:
+        return jnp.concatenate([jnp.zeros((x_rel.shape[0], 1)), x_rel], axis=1)
+    if x_rel.ndim == 3:
+        return jnp.concatenate(
+            [jnp.zeros((x_rel.shape[0], x_rel.shape[1], 1)), x_rel], axis=2
+        )
+    raise ValueError("Expected rank-2 or rank-3 array.")
+
+
+def _posterior_growth_samples(
+    posterior: dict[str, jax.Array]
+) -> tuple[jax.Array, jax.Array]:
+    """Return posterior samples of slopes and city intercepts with reference variant prepended."""
+    slope_rel = (
+        posterior["slope_loc"][:, None]
+        + posterior["slope_scale"][:, None] * posterior["slope_raw"]
+    )
+    slopes = _prepend_reference(slope_rel)
+
+    int_rel = (
+        posterior["intercept_loc"][:, None, :]
+        + posterior["intercept_scale"][:, None, :] * posterior["intercept_raw"]
+    )
+    intercepts = _prepend_reference(int_rel)
+    return slopes, intercepts
+
+
+def _predict_pi_samples(
+    slopes: jax.Array, intercepts_city: jax.Array, t_grid: jax.Array
+) -> jax.Array:
+    """Predict abundance probabilities for posterior growth samples in one city."""
+    logits = intercepts_city[:, None, :] + slopes[:, None, :] * t_grid[None, :, None]
+    return jax.nn.softmax(logits, axis=-1)
+
+
+def _simulate_observed_frequency_samples(
+    key: jax.Array,
+    mu_post: jax.Array,
+    eta_rho_post: jax.Array,
+    predictive_coverage: int,
+    predictive_draws: int | None = None,
+) -> jax.Array:
+    """Simulate posterior predictive observed mutation frequencies Y/N.
+
+    Args:
+        key: PRNG key.
+        mu_post: latent mutation frequencies, shape (samples, cities, time, loci).
+        eta_rho_post: posterior eta_rho samples, shape (samples, loci).
+        predictive_coverage: total read count N used for predictive simulation.
+        predictive_draws: number of posterior predictive draws. If larger than
+            available posterior samples, posterior states are sampled with replacement.
+    """
+    n_post = mu_post.shape[0]
+    if predictive_draws is None:
+        predictive_draws = n_post
+
+    if predictive_draws != n_post:
+        key, key_subsample = jax.random.split(key)
+        idx = jax.random.randint(
+            key_subsample, shape=(predictive_draws,), minval=0, maxval=n_post
+        )
+        mu_post = mu_post[idx]
+        eta_rho_post = eta_rho_post[idx]
+
+    eps_mu = 1e-6
+    mu_clip = jnp.clip(mu_post, eps_mu, 1.0 - eps_mu)
+
+    rho = transform_eta_to_rho(eta_rho_post)  # (samples, loci)
+    kappa = jnp.exp(rho_to_log_kappa(rho))  # (samples, loci)
+    kappa = kappa[:, None, None, :]  # broadcast to (samples, 1, 1, loci)
+
+    alpha = mu_clip * kappa
+    beta = (1.0 - mu_clip) * kappa
+
+    key_beta, key_binom = jax.random.split(key)
+    p = jax.random.beta(key_beta, a=alpha, b=beta, shape=alpha.shape)
+    y = jax.random.binomial(
+        key_binom,
+        n=jnp.asarray(predictive_coverage, dtype=float),
+        p=p,
+        shape=p.shape,
+    )
+    return y / float(predictive_coverage)
+
+
+def _plot_abundance_curves(
+    output_path: Path,
+    t_grid: jax.Array,
+    pi_truth: jax.Array,
+    pi_post: jax.Array,
+) -> plt.Figure:
+    """Plot posterior abundance curves and uncertainty bands against truth for each city."""
+    n_cities = pi_truth.shape[0]
+    n_variants = pi_truth.shape[2]
+    colors = [f"C{i}" for i in range(n_variants)]
+
+    fig, axes = plt.subplots(
+        nrows=n_cities, ncols=1, figsize=(10, 3.2 * n_cities), sharex=True
+    )
+    if n_cities == 1:
+        axes = [axes]
+
+    for c in range(n_cities):
+        ax = axes[c]
+        city_post = pi_post[:, c, :, :]  # (samples, time, variants)
+        city_truth = pi_truth[c, :, :]
+        q05 = jnp.quantile(city_post, 0.05, axis=0)
+        q50 = jnp.quantile(city_post, 0.50, axis=0)
+        q95 = jnp.quantile(city_post, 0.95, axis=0)
+
+        for v in range(n_variants):
+            ax.fill_between(t_grid, q05[:, v], q95[:, v], color=colors[v], alpha=0.2)
+            ax.plot(
+                t_grid,
+                q50[:, v],
+                color=colors[v],
+                linewidth=2,
+                label=f"Variant {v} posterior",
+            )
+            ax.plot(
+                t_grid,
+                city_truth[:, v],
+                color=colors[v],
+                linestyle="--",
+                linewidth=1.5,
+                label=f"Variant {v} truth",
+            )
+
+        ax.set_title(f"City {c}: variant abundance trajectories")
+        ax.set_ylim(-0.02, 1.02)
+        ax.set_ylabel("Abundance")
+        ax.grid(alpha=0.2)
+
+    axes[-1].set_xlabel("Time")
+    handles, labels = axes[0].get_legend_handles_labels()
+    fig.legend(
+        handles[: 2 * n_variants],
+        labels[: 2 * n_variants],
+        loc="upper center",
+        ncols=4,
+        frameon=False,
+    )
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    fig.savefig(output_path, dpi=200)
+    return fig
+
+
+def _plot_mutation_predictions(
+    output_path: Path,
+    t_grid: jax.Array,
+    mu_truth: jax.Array,
+    mu_post: jax.Array,
+    obs_freq_post: jax.Array,
+    sim_data,
+) -> plt.Figure:
+    """Plot observed mutation frequencies with latent and observed predictive bands by city/locus."""
+    n_cities = mu_truth.shape[0]
+    n_loci = mu_truth.shape[2]
+
+    fig, axes = plt.subplots(
+        nrows=n_cities,
+        ncols=n_loci,
+        figsize=(3.2 * n_loci, 2.5 * n_cities),
+        sharex=True,
+        sharey=True,
+    )
+
+    if n_cities == 1:
+        axes = axes[None, :]
+    if n_loci == 1:
+        axes = axes[:, None]
+
+    for c in range(n_cities):
+        city_indices = jnp.where(sim_data.city == c)[0]
+        city_times = sim_data.time[city_indices]
+        order = jnp.argsort(city_times)
+        city_indices = city_indices[order]
+        city_times = city_times[order]
+
+        y_city = sim_data.Y[city_indices]
+        n_city = sim_data.N[city_indices]
+        mask_city = sim_data.obs_mask[city_indices]
+        obs_freq_city = y_city / n_city
+
+        city_mu_post = mu_post[:, c, :, :]  # (samples, time, loci)
+        city_obs_post = obs_freq_post[:, c, :, :]  # (samples, time, loci)
+        city_mu_truth = mu_truth[c, :, :]
+        q05 = jnp.quantile(city_mu_post, 0.05, axis=0)
+        q50 = jnp.quantile(city_mu_post, 0.50, axis=0)
+        q95 = jnp.quantile(city_mu_post, 0.95, axis=0)
+        oq05 = jnp.quantile(city_obs_post, 0.05, axis=0)
+        oq50 = jnp.quantile(city_obs_post, 0.50, axis=0)
+        oq95 = jnp.quantile(city_obs_post, 0.95, axis=0)
+
+        for g in range(n_loci):
+            ax = axes[c, g]
+            # Latent mutation-frequency posterior (mu)
+            ax.fill_between(t_grid, q05[:, g], q95[:, g], color="C0", alpha=0.20)
+            ax.plot(t_grid, q50[:, g], color="C0", linewidth=1.8)
+            # Posterior predictive observed-frequency band (Y/N)
+            ax.fill_between(t_grid, oq05[:, g], oq95[:, g], color="C1", alpha=0.18)
+            ax.plot(t_grid, oq50[:, g], color="C1", linewidth=1.5)
+            ax.plot(
+                t_grid,
+                city_mu_truth[:, g],
+                color="black",
+                linestyle="--",
+                linewidth=1.5,
+            )
+
+            obs_mask = mask_city[:, g]
+            ax.scatter(
+                city_times[obs_mask],
+                obs_freq_city[:, g][obs_mask],
+                s=16,
+                color="C3",
+                alpha=0.8,
+            )
+
+            if c == 0:
+                ax.set_title(f"Locus {g}")
+            if g == 0:
+                ax.set_ylabel(f"City {c}\nFrequency")
+            ax.set_ylim(-0.02, 1.02)
+            ax.grid(alpha=0.2)
+
+    for g in range(n_loci):
+        axes[-1, g].set_xlabel("Time")
+
+    fig.suptitle(
+        "Mutation frequencies: latent vs observed predictive uncertainty", y=1.01
+    )
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=200)
+    return fig
 
 
 def run_demo(
@@ -17,6 +261,11 @@ def run_demo(
     time_max: float = 12.0,
     num_warmup: int = 700,
     num_posterior_samples: int = 700,
+    output_dir: str = "generated/variant_beta_binomial_demo",
+    n_grid: int = 200,
+    predictive_coverage: int | None = None,
+    predictive_draws: int = 4000,
+    show_plots: bool = False,
 ) -> None:
     key = jax.random.PRNGKey(seed)
     key_sim, key_mcmc = jax.random.split(key)
@@ -73,12 +322,11 @@ def run_demo(
     mcmc.print_summary(exclude_deterministic=False)
 
     posterior = mcmc.get_samples()
-    slope_loc = posterior["slope_loc"]
-    slope_scale = posterior["slope_scale"]
-    slope_raw = posterior["slope_raw"]
-
-    slopes_rel = slope_loc[:, None] + slope_scale[:, None] * slope_raw
-    slopes = jnp.concatenate([jnp.zeros((slopes_rel.shape[0], 1)), slopes_rel], axis=1)
+    slopes, intercepts = _posterior_growth_samples(posterior)
+    eta_rho_post = (
+        posterior["eta_loc"][:, None]
+        + posterior["eta_scale"][:, None] * posterior["eta_raw"]
+    )
 
     slopes_post_mean = jnp.mean(slopes, axis=0)
     slopes_q05 = jnp.quantile(slopes, 0.05, axis=0)
@@ -100,6 +348,74 @@ def run_demo(
         float(jnp.mean(true_eta_rho)),
         ")",
     )
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    t_grid = jnp.linspace(0.0, time_max, n_grid)
+    a_float = A.astype(float)
+
+    pi_truth = []
+    mu_truth = []
+    pi_post = []
+    mu_post = []
+    for c in range(C):
+        logits_truth = (
+            true_intercepts[c][None, :] + true_slopes[None, :] * t_grid[:, None]
+        )
+        pi_city_truth = jax.nn.softmax(logits_truth, axis=-1)
+        mu_city_truth = pi_city_truth @ a_float
+
+        pi_city_post = _predict_pi_samples(
+            slopes=slopes, intercepts_city=intercepts[:, c, :], t_grid=t_grid
+        )
+        mu_city_post = jnp.einsum("stv,vg->stg", pi_city_post, a_float)
+
+        pi_truth.append(pi_city_truth)
+        mu_truth.append(mu_city_truth)
+        pi_post.append(pi_city_post)
+        mu_post.append(mu_city_post)
+
+    pi_truth = jnp.stack(pi_truth, axis=0)
+    mu_truth = jnp.stack(mu_truth, axis=0)
+    pi_post = jnp.stack(pi_post, axis=1)
+    mu_post = jnp.stack(mu_post, axis=1)
+
+    if predictive_coverage is None:
+        predictive_coverage = coverage_n
+    key_pred = jax.random.fold_in(key, 97)
+    obs_freq_post = _simulate_observed_frequency_samples(
+        key=key_pred,
+        mu_post=mu_post,
+        eta_rho_post=eta_rho_post,
+        predictive_coverage=predictive_coverage,
+        predictive_draws=predictive_draws,
+    )
+
+    abundance_path = out_dir / "abundance_curves_by_city.png"
+    mutation_path = out_dir / "mutation_predictions_by_city_locus.png"
+
+    fig1 = _plot_abundance_curves(
+        output_path=abundance_path,
+        t_grid=t_grid,
+        pi_truth=pi_truth,
+        pi_post=pi_post,
+    )
+    fig2 = _plot_mutation_predictions(
+        output_path=mutation_path,
+        t_grid=t_grid,
+        mu_truth=mu_truth,
+        mu_post=mu_post,
+        obs_freq_post=obs_freq_post,
+        sim_data=sim.data,
+    )
+    print("\nSaved plots:")
+    print("-", abundance_path)
+    print("-", mutation_path)
+    if show_plots:
+        plt.show()
+    plt.close(fig1)
+    plt.close(fig2)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -137,6 +453,35 @@ def _parse_args() -> argparse.Namespace:
         default=700,
         help="Number of posterior samples.",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="generated/variant_beta_binomial_demo",
+        help="Directory for output plots.",
+    )
+    parser.add_argument(
+        "--n-grid",
+        type=int,
+        default=200,
+        help="Number of time grid points for predictive plotting.",
+    )
+    parser.add_argument(
+        "--predictive-coverage",
+        type=int,
+        default=None,
+        help="Coverage N used to simulate observed-frequency predictive bands (default: --coverage).",
+    )
+    parser.add_argument(
+        "--predictive-draws",
+        type=int,
+        default=4000,
+        help="Number of posterior predictive draws used for observed-frequency bands.",
+    )
+    parser.add_argument(
+        "--show-plots",
+        action="store_true",
+        help="Display plots interactively after saving.",
+    )
     return parser.parse_args()
 
 
@@ -149,4 +494,9 @@ if __name__ == "__main__":
         time_max=args.time_max,
         num_warmup=args.warmup,
         num_posterior_samples=args.samples,
+        output_dir=args.output_dir,
+        n_grid=args.n_grid,
+        predictive_coverage=args.predictive_coverage,
+        predictive_draws=args.predictive_draws,
+        show_plots=args.show_plots,
     )

--- a/examples/variant_beta_binomial_hierarchical_bayes.py
+++ b/examples/variant_beta_binomial_hierarchical_bayes.py
@@ -1,11 +1,14 @@
 """End-to-end hierarchical Bayesian inference demo for variant beta-binomial model."""
 
 import argparse
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
+import numpyro.optim as optim
 from covvfit._variant_beta_binomial.dispersion import (
     rho_to_log_kappa,
     transform_eta_to_rho,
@@ -13,7 +16,16 @@ from covvfit._variant_beta_binomial.dispersion import (
 from covvfit._variant_beta_binomial.growth import LinearGrowthParams
 from covvfit._variant_beta_binomial.numpyro_model import numpyro_model_hierarchical
 from covvfit._variant_beta_binomial.simulate import simulate_dataset
-from numpyro.infer import MCMC, NUTS
+from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO
+from numpyro.infer.autoguide import (
+    AutoBNAFNormal,
+    AutoIAFNormal,
+    AutoLowRankMultivariateNormal,
+    AutoNormal,
+)
+
+SviGuideName = Literal["lowrank", "autonormal", "iaf", "bnaf"]
+ScenarioName = Literal["baseline", "dramatic_emergence"]
 
 
 def _prepend_reference(x_rel: jax.Array) -> jax.Array:
@@ -254,13 +266,295 @@ def _plot_mutation_predictions(
     return fig
 
 
+@dataclass(frozen=True)
+class InferenceResult:
+    method: str
+    posterior: dict[str, jax.Array]
+
+
+@dataclass(frozen=True)
+class ScenarioConfig:
+    name: ScenarioName
+    description: str
+    n_cities: int
+    true_intercepts: jax.Array
+    true_slopes: jax.Array
+    A: jax.Array
+    true_eta_rho: jax.Array
+    mask_probability: float
+
+
+def _make_scenario_config(scenario: ScenarioName) -> ScenarioConfig:
+    if scenario == "baseline":
+        return ScenarioConfig(
+            name="baseline",
+            description=(
+                "Moderate growth with all variants present over time; useful for"
+                " standard recovery checks."
+            ),
+            n_cities=3,
+            true_intercepts=jnp.array(
+                [
+                    [0.0, 0.7, -0.2, 0.1],
+                    [0.0, 0.5, 0.1, -0.3],
+                    [0.0, 0.8, 0.3, -0.1],
+                ],
+                dtype=float,
+            ),
+            true_slopes=jnp.array([0.0, 0.05, -0.02, 0.03], dtype=float),
+            A=jnp.array(
+                [
+                    [1, 0, 1, 0, 1, 0],
+                    [0, 1, 1, 0, 0, 1],
+                    [1, 1, 0, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 1],
+                ],
+                dtype=bool,
+            ),
+            true_eta_rho=jnp.array([-0.3, -0.1, 0.2, -0.4, 0.1, 0.0], dtype=float),
+            mask_probability=0.1,
+        )
+
+    if scenario == "dramatic_emergence":
+        return ScenarioConfig(
+            name="dramatic_emergence",
+            description=(
+                "Three-variant emergence scenario: variant 0 dominates early, then"
+                " variants 1 and 2 emerge; variant 2 becomes the final dominant"
+                " lineage."
+            ),
+            n_cities=3,
+            true_intercepts=jnp.array(
+                [
+                    [0.0, -7.0, -9.0],
+                    [0.0, -7.5, -9.5],
+                    [0.0, -6.8, -8.8],
+                ],
+                dtype=float,
+            ),
+            true_slopes=jnp.array([0.0, 0.90, 1.20], dtype=float),
+            A=jnp.array(
+                [
+                    [1, 0, 1, 0, 0],
+                    [0, 1, 1, 1, 0],
+                    [0, 0, 1, 1, 1],
+                ],
+                dtype=bool,
+            ),
+            true_eta_rho=jnp.array([-0.35, -0.15, 0.0, 0.05, 0.2], dtype=float),
+            mask_probability=0.08,
+        )
+
+    raise ValueError(f"Unsupported scenario: {scenario}")
+
+
+def _run_hmc_inference(
+    key: jax.Array,
+    data,
+    n_cities: int,
+    num_warmup: int,
+    num_posterior_samples: int,
+    target_accept_prob: float,
+) -> InferenceResult:
+    nuts = NUTS(numpyro_model_hierarchical, target_accept_prob=target_accept_prob)
+    mcmc = MCMC(
+        nuts,
+        num_warmup=num_warmup,
+        num_samples=num_posterior_samples,
+        num_chains=1,
+        progress_bar=False,
+    )
+    mcmc.run(key, data=data, n_cities=n_cities)
+    mcmc.print_summary(exclude_deterministic=False)
+    extra = mcmc.get_extra_fields()
+    if "diverging" in extra:
+        print(f"Number of divergences: {int(jnp.sum(extra['diverging']))}")
+    return InferenceResult(method="hmc", posterior=mcmc.get_samples())
+
+
+def _run_svi_inference(
+    key: jax.Array,
+    data,
+    n_cities: int,
+    num_posterior_samples: int,
+    svi_steps: int,
+    svi_lr: float,
+    svi_guide: SviGuideName,
+    svi_rank: int,
+    svi_num_flows: int,
+    svi_iaf_hidden_dims: tuple[int, ...],
+    svi_bnaf_hidden_factors: tuple[int, ...],
+    svi_restarts: int,
+) -> InferenceResult:
+    if svi_restarts < 1:
+        raise ValueError("svi_restarts must be >= 1.")
+
+    def _make_guide():
+        if svi_guide == "lowrank":
+            return AutoLowRankMultivariateNormal(
+                numpyro_model_hierarchical, rank=svi_rank
+            )
+        if svi_guide == "autonormal":
+            return AutoNormal(numpyro_model_hierarchical)
+        if svi_guide == "iaf":
+            return AutoIAFNormal(
+                numpyro_model_hierarchical,
+                num_flows=svi_num_flows,
+                hidden_dims=svi_iaf_hidden_dims,
+            )
+        if svi_guide == "bnaf":
+            return AutoBNAFNormal(
+                numpyro_model_hierarchical,
+                num_flows=svi_num_flows,
+                hidden_factors=list(svi_bnaf_hidden_factors),
+            )
+        raise ValueError(f"Unsupported SVI guide: {svi_guide}")
+
+    best_result = None
+    best_guide = None
+    best_loss = None
+    best_restart = None
+
+    for restart in range(svi_restarts):
+        key, key_restart = jax.random.split(key)
+        guide = _make_guide()
+        svi = SVI(
+            numpyro_model_hierarchical,
+            guide,
+            optim.Adam(svi_lr),
+            Trace_ELBO(),
+        )
+        try:
+            svi_result = svi.run(
+                key_restart,
+                svi_steps,
+                data=data,
+                n_cities=n_cities,
+                progress_bar=False,
+            )
+        except ValueError as exc:
+            if (
+                svi_guide == "iaf"
+                and "Hidden dimension must not be less than input dimension" in str(exc)
+            ):
+                raise ValueError(
+                    "AutoIAFNormal requires every --svi-iaf-hidden-dims entry to be >= latent dimension. "
+                    "Increase hidden dims (for example: --svi-iaf-hidden-dims 128,128)."
+                ) from exc
+            raise
+        final_loss = float(jnp.asarray(svi_result.losses)[-1])
+        if not jnp.isfinite(final_loss):
+            print(
+                f"  SVI restart {restart + 1}/{svi_restarts}: final_loss is non-finite ({final_loss}); skipping."
+            )
+            continue
+        print(
+            f"  SVI restart {restart + 1}/{svi_restarts}: final_loss={final_loss:.4f}"
+        )
+
+        if best_loss is None or final_loss < best_loss:
+            best_loss = final_loss
+            best_result = svi_result
+            best_guide = guide
+            best_restart = restart + 1
+
+    if best_result is None or best_guide is None or best_loss is None:
+        raise ValueError(
+            "All SVI restarts produced non-finite final losses. "
+            "Try lowering --svi-lr, increasing --svi-steps/restarts, "
+            "or using a more stable guide (for example --svi-guide bnaf or lowrank)."
+        )
+
+    post_key = jax.random.fold_in(key, 1)
+    posterior = best_guide.sample_posterior(
+        post_key,
+        best_result.params,
+        sample_shape=(num_posterior_samples,),
+        data=data,
+        n_cities=n_cities,
+    )
+    losses = jnp.asarray(best_result.losses)
+    print("\nSVI summary:")
+    print("  guide:", svi_guide)
+    if svi_guide == "lowrank":
+        print("  guide_rank:", svi_rank)
+    if svi_guide in ("iaf", "bnaf"):
+        print("  num_flows:", svi_num_flows)
+    if svi_guide == "iaf":
+        print("  iaf_hidden_dims:", svi_iaf_hidden_dims)
+    if svi_guide == "bnaf":
+        print("  bnaf_hidden_factors:", svi_bnaf_hidden_factors)
+    print("  restarts:", svi_restarts)
+    print("  selected_restart:", best_restart)
+    print("  steps:", svi_steps)
+    print("  learning_rate:", svi_lr)
+    print("  initial_loss:", float(losses[0]))
+    print("  final_loss:", float(losses[-1]))
+    return InferenceResult(method="svi", posterior=posterior)
+
+
+def _run_inference(
+    method: Literal["hmc", "svi"],
+    key: jax.Array,
+    data,
+    n_cities: int,
+    num_warmup: int,
+    num_posterior_samples: int,
+    target_accept_prob: float,
+    svi_steps: int,
+    svi_lr: float,
+    svi_guide: SviGuideName,
+    svi_rank: int,
+    svi_num_flows: int,
+    svi_iaf_hidden_dims: tuple[int, ...],
+    svi_bnaf_hidden_factors: tuple[int, ...],
+    svi_restarts: int,
+) -> InferenceResult:
+    if method == "hmc":
+        return _run_hmc_inference(
+            key=key,
+            data=data,
+            n_cities=n_cities,
+            num_warmup=num_warmup,
+            num_posterior_samples=num_posterior_samples,
+            target_accept_prob=target_accept_prob,
+        )
+    if method == "svi":
+        return _run_svi_inference(
+            key=key,
+            data=data,
+            n_cities=n_cities,
+            num_posterior_samples=num_posterior_samples,
+            svi_steps=svi_steps,
+            svi_lr=svi_lr,
+            svi_guide=svi_guide,
+            svi_rank=svi_rank,
+            svi_num_flows=svi_num_flows,
+            svi_iaf_hidden_dims=svi_iaf_hidden_dims,
+            svi_bnaf_hidden_factors=svi_bnaf_hidden_factors,
+            svi_restarts=svi_restarts,
+        )
+    raise ValueError(f"Unsupported inference method: {method}")
+
+
 def run_demo(
     seed: int = 0,
+    scenario: ScenarioName = "baseline",
     n_samples: int = 180,
     coverage_n: int = 300,
     time_max: float = 12.0,
+    inference_method: Literal["hmc", "svi"] = "hmc",
     num_warmup: int = 700,
     num_posterior_samples: int = 700,
+    target_accept_prob: float = 0.95,
+    svi_steps: int = 5000,
+    svi_lr: float = 1e-2,
+    svi_guide: SviGuideName = "lowrank",
+    svi_rank: int = 8,
+    svi_num_flows: int = 2,
+    svi_iaf_hidden_dims: tuple[int, ...] = (128, 128),
+    svi_bnaf_hidden_factors: tuple[int, ...] = (8, 8),
+    svi_restarts: int = 3,
     output_dir: str = "generated/variant_beta_binomial_demo",
     n_grid: int = 200,
     predictive_coverage: int | None = None,
@@ -268,36 +562,32 @@ def run_demo(
     show_plots: bool = False,
 ) -> None:
     key = jax.random.PRNGKey(seed)
-    key_sim, key_mcmc = jax.random.split(key)
+    key_sim, key_infer = jax.random.split(key)
 
-    C = 3
-    G = 6
-    city = jnp.repeat(jnp.arange(C, dtype=jnp.int32), n_samples // C)
-    time = jnp.tile(jnp.linspace(0.0, time_max, n_samples // C), C)
+    config = _make_scenario_config(scenario)
+    C = config.n_cities
+    if n_samples % C != 0:
+        raise ValueError(
+            f"n_samples ({n_samples}) must be divisible by number of cities ({C}) for scenario '{scenario}'."
+        )
+    samples_per_city = n_samples // C
+    city = jnp.repeat(jnp.arange(C, dtype=jnp.int32), samples_per_city)
+    time = jnp.tile(jnp.linspace(0.0, time_max, samples_per_city), C)
 
-    true_intercepts = jnp.array(
-        [
-            [0.0, 0.7, -0.2, 0.1],
-            [0.0, 0.5, 0.1, -0.3],
-            [0.0, 0.8, 0.3, -0.1],
-        ],
-        dtype=float,
-    )
-    true_slopes = jnp.array([0.0, 0.05, -0.02, 0.03], dtype=float)
-
+    true_intercepts = config.true_intercepts
+    true_slopes = config.true_slopes
+    A = config.A
+    G = A.shape[1]
     growth_true = LinearGrowthParams(intercepts=true_intercepts, slopes=true_slopes)
-
-    A = jnp.array(
-        [
-            [1, 0, 1, 0, 1, 0],
-            [0, 1, 1, 0, 0, 1],
-            [1, 1, 0, 1, 0, 0],
-            [0, 0, 1, 1, 1, 1],
-        ],
-        dtype=bool,
-    )
     coverage = jnp.full((n_samples, G), coverage_n, dtype=jnp.int32)
-    true_eta_rho = jnp.array([-0.3, -0.1, 0.2, -0.4, 0.1, 0.0], dtype=float)
+    true_eta_rho = config.true_eta_rho
+
+    pi_start = jax.nn.softmax(true_intercepts[0] + true_slopes * 0.0, axis=-1)
+    pi_end = jax.nn.softmax(true_intercepts[0] + true_slopes * time_max, axis=-1)
+    print(f"Scenario: {config.name}")
+    print(config.description)
+    print("City 0 variant prevalence at t=0:", pi_start)
+    print(f"City 0 variant prevalence at t={time_max}:", pi_end)
 
     sim = simulate_dataset(
         key=key_sim,
@@ -307,21 +597,28 @@ def run_demo(
         city=city,
         time=time,
         coverage=coverage,
-        mask_probability=0.1,
+        mask_probability=config.mask_probability,
     )
 
-    nuts = NUTS(numpyro_model_hierarchical, target_accept_prob=0.95)
-    mcmc = MCMC(
-        nuts,
+    inference_result = _run_inference(
+        method=inference_method,
+        key=key_infer,
+        data=sim.data,
+        n_cities=C,
         num_warmup=num_warmup,
-        num_samples=num_posterior_samples,
-        num_chains=1,
-        progress_bar=False,
+        num_posterior_samples=num_posterior_samples,
+        target_accept_prob=target_accept_prob,
+        svi_steps=svi_steps,
+        svi_lr=svi_lr,
+        svi_guide=svi_guide,
+        svi_rank=svi_rank,
+        svi_num_flows=svi_num_flows,
+        svi_iaf_hidden_dims=svi_iaf_hidden_dims,
+        svi_bnaf_hidden_factors=svi_bnaf_hidden_factors,
+        svi_restarts=svi_restarts,
     )
-    mcmc.run(key_mcmc, data=sim.data, n_cities=C)
-    mcmc.print_summary(exclude_deterministic=False)
-
-    posterior = mcmc.get_samples()
+    posterior = inference_result.posterior
+    print(f"\nInference method: {inference_result.method.upper()}")
     slopes, intercepts = _posterior_growth_samples(posterior)
     eta_rho_post = (
         posterior["eta_loc"][:, None]
@@ -419,10 +716,31 @@ def run_demo(
 
 
 def _parse_args() -> argparse.Namespace:
+    def _parse_int_list(value: str) -> tuple[int, ...]:
+        items = [item.strip() for item in value.split(",") if item.strip()]
+        if not items:
+            raise argparse.ArgumentTypeError("Expected a comma-separated list of ints.")
+        try:
+            values = tuple(int(item) for item in items)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                "Expected a comma-separated list of ints."
+            ) from exc
+        if any(v < 1 for v in values):
+            raise argparse.ArgumentTypeError("All values must be >= 1.")
+        return values
+
     parser = argparse.ArgumentParser(
         description="Run hierarchical Bayesian inference demo for variant beta-binomial model."
     )
     parser.add_argument("--seed", type=int, default=0, help="Random seed.")
+    parser.add_argument(
+        "--scenario",
+        type=str,
+        choices=["baseline", "dramatic_emergence"],
+        default="baseline",
+        help="Simulation preset. Use dramatic_emergence for sharp takeover dynamics.",
+    )
     parser.add_argument(
         "--n-samples",
         type=int,
@@ -442,16 +760,78 @@ def _parse_args() -> argparse.Namespace:
         help="Maximum simulation time.",
     )
     parser.add_argument(
+        "--inference-method",
+        type=str,
+        choices=["hmc", "svi"],
+        default="hmc",
+        help="Inference backend to use.",
+    )
+    parser.add_argument(
         "--warmup",
         type=int,
         default=700,
-        help="Number of NUTS warmup steps.",
+        help="Number of NUTS warmup steps (HMC only).",
     )
     parser.add_argument(
         "--samples",
         type=int,
         default=700,
-        help="Number of posterior samples.",
+        help="Number of posterior samples to draw (HMC or guide posterior samples for SVI).",
+    )
+    parser.add_argument(
+        "--target-accept-prob",
+        type=float,
+        default=0.95,
+        help="NUTS target acceptance probability (HMC only).",
+    )
+    parser.add_argument(
+        "--svi-steps",
+        type=int,
+        default=5000,
+        help="Number of optimization steps for SVI.",
+    )
+    parser.add_argument(
+        "--svi-lr",
+        type=float,
+        default=1e-2,
+        help="Learning rate for SVI optimizer.",
+    )
+    parser.add_argument(
+        "--svi-guide",
+        type=str,
+        choices=["lowrank", "autonormal", "iaf", "bnaf"],
+        default="lowrank",
+        help="SVI guide family (NumPyro autoguides only; iaf is more fragile).",
+    )
+    parser.add_argument(
+        "--svi-rank",
+        type=int,
+        default=8,
+        help="Rank for low-rank SVI guide (used when --svi-guide=lowrank).",
+    )
+    parser.add_argument(
+        "--svi-num-flows",
+        type=int,
+        default=2,
+        help="Number of flow transforms (used with --svi-guide=iaf/bnaf).",
+    )
+    parser.add_argument(
+        "--svi-iaf-hidden-dims",
+        type=_parse_int_list,
+        default=(128, 128),
+        help="Comma-separated hidden dimensions for AutoIAFNormal (e.g. 128,128).",
+    )
+    parser.add_argument(
+        "--svi-bnaf-hidden-factors",
+        type=_parse_int_list,
+        default=(8, 8),
+        help="Comma-separated hidden factors for AutoBNAFNormal (e.g. 8,8).",
+    )
+    parser.add_argument(
+        "--svi-restarts",
+        type=int,
+        default=3,
+        help="Number of SVI restarts; best final ELBO is selected.",
     )
     parser.add_argument(
         "--output-dir",
@@ -489,11 +869,22 @@ if __name__ == "__main__":
     args = _parse_args()
     run_demo(
         seed=args.seed,
+        scenario=args.scenario,
         n_samples=args.n_samples,
         coverage_n=args.coverage,
         time_max=args.time_max,
+        inference_method=args.inference_method,
         num_warmup=args.warmup,
         num_posterior_samples=args.samples,
+        target_accept_prob=args.target_accept_prob,
+        svi_steps=args.svi_steps,
+        svi_lr=args.svi_lr,
+        svi_guide=args.svi_guide,
+        svi_rank=args.svi_rank,
+        svi_num_flows=args.svi_num_flows,
+        svi_iaf_hidden_dims=args.svi_iaf_hidden_dims,
+        svi_bnaf_hidden_factors=args.svi_bnaf_hidden_factors,
+        svi_restarts=args.svi_restarts,
         output_dir=args.output_dir,
         n_grid=args.n_grid,
         predictive_coverage=args.predictive_coverage,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ plugins:
 nav:
   - Overview: index.md
   - Command line workflow: cli.md
+  - Hierarchical Bayesian example: variant_beta_binomial_example.md
   - API Reference: api/index.md
   - Statistical models: models.md
   - For developers: developers.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - Overview: index.md
   - Command line workflow: cli.md
   - Hierarchical Bayesian example: variant_beta_binomial_example.md
+  - Variational inference guidelines: variational_inference_guidelines.md
   - API Reference: api/index.md
   - Statistical models: models.md
   - For developers: developers.md

--- a/src/covvfit/__init__.py
+++ b/src/covvfit/__init__.py
@@ -2,6 +2,7 @@ import covvfit._deconvolution as deconvolution
 import covvfit._dynamics as dynamics
 import covvfit._numeric as numeric
 import covvfit._quasimultinomial as quasimultinomial
+import covvfit._variant_beta_binomial as variant_beta_binomial
 
 try:
     import covvfit.simulation as simulation
@@ -16,6 +17,14 @@ except Exception as e:
 import covvfit._preprocess_abundances as preprocess
 import covvfit.plotting as plot
 from covvfit._splines import create_spline_matrix
+from covvfit._variant_beta_binomial import (
+    DispersionParams,
+    LinearGrowthParams,
+    ModelData,
+    model_loglik,
+    numpyro_model_hierarchical,
+    simulate_dataset,
+)
 
 VERSION = "0.3.1"
 
@@ -28,6 +37,13 @@ __all__ = [
     "VERSION",
     "numeric",
     "quasimultinomial",
+    "variant_beta_binomial",
+    "ModelData",
+    "DispersionParams",
+    "LinearGrowthParams",
+    "model_loglik",
+    "numpyro_model_hierarchical",
+    "simulate_dataset",
     "plot",
     "preprocess",
     "simulation",

--- a/src/covvfit/_variant_beta_binomial/__init__.py
+++ b/src/covvfit/_variant_beta_binomial/__init__.py
@@ -1,0 +1,60 @@
+"""Private subpackage for multi-city variant beta-binomial model."""
+
+from covvfit._variant_beta_binomial.data import DispersionParams, ModelData
+from covvfit._variant_beta_binomial.dispersion import (
+    build_eta_rho,
+    rho_to_log_kappa,
+    select_rho_per_sample,
+    transform_eta_to_rho,
+)
+from covvfit._variant_beta_binomial.growth import (
+    LinearGrowthParams,
+    compute_log_pi,
+    effective_theta,
+    log_f,
+)
+from covvfit._variant_beta_binomial.likelihood import (
+    beta_binomial_logpmf,
+    make_beta_binomial_shapes,
+    masked_beta_binomial_loglik,
+)
+from covvfit._variant_beta_binomial.mapping import (
+    compute_log_mu,
+    compute_mu,
+    make_log_A_mask,
+)
+from covvfit._variant_beta_binomial.model import model_loglik
+from covvfit._variant_beta_binomial.numpyro_model import numpyro_model_hierarchical
+from covvfit._variant_beta_binomial.simulate import (
+    SimulationResult,
+    sample_beta_binomial_counts,
+    simulate_dataset,
+    simulate_log_pi,
+    simulate_mu,
+)
+
+__all__ = [
+    "ModelData",
+    "DispersionParams",
+    "LinearGrowthParams",
+    "SimulationResult",
+    "effective_theta",
+    "log_f",
+    "compute_log_pi",
+    "make_log_A_mask",
+    "compute_log_mu",
+    "compute_mu",
+    "build_eta_rho",
+    "transform_eta_to_rho",
+    "rho_to_log_kappa",
+    "select_rho_per_sample",
+    "make_beta_binomial_shapes",
+    "beta_binomial_logpmf",
+    "masked_beta_binomial_loglik",
+    "sample_beta_binomial_counts",
+    "simulate_log_pi",
+    "simulate_mu",
+    "simulate_dataset",
+    "model_loglik",
+    "numpyro_model_hierarchical",
+]

--- a/src/covvfit/_variant_beta_binomial/data.py
+++ b/src/covvfit/_variant_beta_binomial/data.py
@@ -1,0 +1,93 @@
+"""Data containers for variant beta-binomial model."""
+
+from dataclasses import dataclass
+
+import jax.numpy as jnp
+from jaxtyping import Array, Bool, Float, Int
+
+# Axis-name sentinels for Ruff/Pyflakes handling of jaxtyping string annotations.
+samples = loci = variants = features = shape = None
+
+
+@dataclass(frozen=True)
+class ModelData:
+    """Observed data for the multi-city beta-binomial model."""
+
+    Y: Int[Array, "samples loci"]
+    N: Int[Array, "samples loci"]
+    city: Int[Array, "samples"]
+    time: Float[Array, "samples"]
+    A: Bool[Array, "variants loci"]
+    obs_mask: Bool[Array, "samples loci"]
+    X: Float[Array, "samples features"] | None = None
+
+    def __post_init__(self) -> None:
+        Y = jnp.asarray(self.Y)
+        N = jnp.asarray(self.N)
+        city = jnp.asarray(self.city)
+        time = jnp.asarray(self.time)
+        A = jnp.asarray(self.A)
+        obs_mask = jnp.asarray(self.obs_mask)
+
+        object.__setattr__(self, "Y", Y)
+        object.__setattr__(self, "N", N)
+        object.__setattr__(self, "city", city)
+        object.__setattr__(self, "time", time)
+        object.__setattr__(self, "A", A)
+        object.__setattr__(self, "obs_mask", obs_mask)
+
+        if self.X is not None:
+            object.__setattr__(self, "X", jnp.asarray(self.X))
+
+        if Y.ndim != 2 or N.ndim != 2:
+            raise ValueError("Y and N must be 2D arrays with shape (samples, loci).")
+        if Y.shape != N.shape:
+            raise ValueError("Y and N must have identical shapes.")
+
+        n_samples, n_loci = Y.shape
+
+        if city.ndim != 1 or city.shape[0] != n_samples:
+            raise ValueError("city must have shape (samples,).")
+        if time.ndim != 1 or time.shape[0] != n_samples:
+            raise ValueError("time must have shape (samples,).")
+        if obs_mask.ndim != 2 or obs_mask.shape != (n_samples, n_loci):
+            raise ValueError("obs_mask must have shape (samples, loci).")
+        if A.ndim != 2 or A.shape[1] != n_loci:
+            raise ValueError("A must have shape (variants, loci) with matching loci.")
+
+        if not jnp.issubdtype(city.dtype, jnp.integer):
+            raise ValueError("city must have integer dtype.")
+        if obs_mask.dtype != jnp.bool_:
+            raise ValueError("obs_mask must have boolean dtype.")
+
+        if not jnp.all((A == 0) | (A == 1)):
+            raise ValueError("A must be binary (values in {0, 1}).")
+        if not jnp.all(jnp.sum(A, axis=0) > 0):
+            raise ValueError("Every locus must be present in at least one variant.")
+
+        if not jnp.issubdtype(Y.dtype, jnp.integer):
+            raise ValueError("Y must have integer dtype.")
+        if not jnp.issubdtype(N.dtype, jnp.integer):
+            raise ValueError("N must have integer dtype.")
+        if not jnp.all(Y >= 0):
+            raise ValueError("Y must be non-negative.")
+        if not jnp.all(N >= 0):
+            raise ValueError("N must be non-negative.")
+        if not jnp.all(Y <= N):
+            raise ValueError("Y must satisfy Y <= N elementwise.")
+
+        if self.X is not None:
+            if self.X.ndim != 2 or self.X.shape[0] != n_samples:
+                raise ValueError("X must have shape (samples, features).")
+
+
+@dataclass(frozen=True)
+class DispersionParams:
+    """Unconstrained dispersion parameters for rho predictor."""
+
+    eta_rho: Float[Array, "*shape"]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "eta_rho", jnp.asarray(self.eta_rho, dtype=float))
+        if self.eta_rho.ndim not in (1, 2):
+            raise ValueError("eta_rho must have shape (loci,) or (cities, loci).")

--- a/src/covvfit/_variant_beta_binomial/dispersion.py
+++ b/src/covvfit/_variant_beta_binomial/dispersion.py
@@ -1,0 +1,56 @@
+"""Dispersion parameterization utilities for beta-binomial model."""
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+# Axis-name sentinels for Ruff/Pyflakes handling of jaxtyping string annotations.
+samples = features = shape = None
+
+
+def build_eta_rho(
+    params_rho: Float[Array, "*shape"],
+    city: Int[Array, "samples"] | None = None,
+    X: Float[Array, "samples features"] | None = None,
+) -> Float[Array, "*shape"]:
+    """Construct unconstrained predictor for rho.
+
+    Current implementation is identity, with placeholders for future predictors.
+    """
+    del city, X
+    return jnp.asarray(params_rho, dtype=float)
+
+
+def transform_eta_to_rho(
+    eta_rho: Float[Array, "*shape"], eps_rho: float = 1e-8
+) -> Float[Array, "*shape"]:
+    """Map unconstrained predictor to rho in (eps_rho, 1-eps_rho)."""
+    eta_rho = jnp.asarray(eta_rho, dtype=float)
+    min_eps = float(jnp.finfo(eta_rho.dtype).eps)
+    eps = jnp.asarray(max(eps_rho, min_eps), dtype=eta_rho.dtype)
+    return eps + (1.0 - 2.0 * eps) * jax.nn.sigmoid(eta_rho)
+
+
+def rho_to_log_kappa(rho: Float[Array, "*shape"]) -> Float[Array, "*shape"]:
+    """Compute log concentration kappa = (1-rho)/rho."""
+    rho = jnp.asarray(rho, dtype=float)
+    return jnp.log1p(-rho) - jnp.log(rho)
+
+
+def select_rho_per_sample(
+    rho: Float[Array, "*shape"], city: Int[Array, "samples"] | None
+) -> Float[Array, "*shape"]:
+    """Select rho by city when rho is city-specific."""
+    rho = jnp.asarray(rho, dtype=float)
+
+    if rho.ndim == 1:
+        return rho
+    if rho.ndim == 2:
+        if city is None:
+            raise ValueError("city is required when rho has shape (cities, loci).")
+        city = jnp.asarray(city)
+        if city.ndim != 1:
+            raise ValueError("city must have shape (samples,).")
+        return rho[city]
+
+    raise ValueError("rho must have shape (loci,) or (cities, loci).")

--- a/src/covvfit/_variant_beta_binomial/growth.py
+++ b/src/covvfit/_variant_beta_binomial/growth.py
@@ -1,0 +1,99 @@
+"""Growth utilities for variant beta-binomial model."""
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+# Axis-name sentinels for Ruff/Pyflakes handling of jaxtyping string annotations.
+variants = features = samples = None
+
+
+@dataclass(frozen=True)
+class LinearGrowthParams:
+    """Simple demo growth parameters.
+
+    intercepts has shape (cities, variants), slopes has shape (variants,).
+    """
+
+    intercepts: Float[Array, "cities variants"]
+    slopes: Float[Array, "variants"]
+
+    def __post_init__(self) -> None:
+        intercepts = jnp.asarray(self.intercepts, dtype=float)
+        slopes = jnp.asarray(self.slopes, dtype=float)
+
+        object.__setattr__(self, "intercepts", intercepts)
+        object.__setattr__(self, "slopes", slopes)
+
+        if intercepts.ndim != 2:
+            raise ValueError("intercepts must have shape (cities, variants).")
+        if slopes.ndim != 1:
+            raise ValueError("slopes must have shape (variants,).")
+        if intercepts.shape[1] != slopes.shape[0]:
+            raise ValueError("intercepts and slopes must share the variants dimension.")
+
+
+@dataclass(frozen=True)
+class LinearGrowthThetaEff:
+    """Effective growth parameters for one sample."""
+
+    intercepts: Float[Array, "variants"]
+    slopes: Float[Array, "variants"]
+
+
+def effective_theta(
+    theta: LinearGrowthParams,
+    city_index: Int[Array, ""] | int,
+    x_row: Float[Array, "features"] | None = None,
+) -> LinearGrowthThetaEff:
+    """Return sample-specific effective growth parameters.
+
+    `x_row` is currently unused and reserved for future covariate terms.
+    """
+    del x_row
+    return LinearGrowthThetaEff(
+        intercepts=theta.intercepts[city_index],
+        slopes=theta.slopes,
+    )
+
+
+def log_f(
+    t: Float[Array, ""] | float, theta_eff: LinearGrowthThetaEff
+) -> Float[Array, " variants"]:
+    """Compute unnormalized log-prevalence scores for one sample."""
+    return theta_eff.intercepts + theta_eff.slopes * t
+
+
+def compute_log_pi(
+    theta: LinearGrowthParams,
+    city: Int[Array, "samples"],
+    time: Float[Array, "samples"],
+    X: Float[Array, "samples features"] | None = None,
+) -> Float[Array, "samples variants"]:
+    """Compute sample-wise log-prevalence scores."""
+
+    city = jnp.asarray(city)
+    time = jnp.asarray(time, dtype=float)
+
+    if city.ndim != 1 or time.ndim != 1 or city.shape[0] != time.shape[0]:
+        raise ValueError("city and time must have shape (samples,).")
+
+    if X is None:
+
+        def _sample_log_pi(c, t):
+            theta_eff = effective_theta(theta, c, None)
+            return log_f(t, theta_eff)
+
+        return jax.vmap(_sample_log_pi)(city, time)
+
+    X = jnp.asarray(X, dtype=float)
+    if X.ndim != 2 or X.shape[0] != city.shape[0]:
+        raise ValueError("X must have shape (samples, features).")
+
+    def _sample_log_pi(c, t, x):
+        theta_eff = effective_theta(theta, c, x)
+        return log_f(t, theta_eff)
+
+    return jax.vmap(_sample_log_pi)(city, time, X)

--- a/src/covvfit/_variant_beta_binomial/likelihood.py
+++ b/src/covvfit/_variant_beta_binomial/likelihood.py
@@ -1,0 +1,77 @@
+"""Likelihood utilities for variant beta-binomial model."""
+
+import jax.numpy as jnp
+from jax.scipy.special import betaln, gammaln
+from jaxtyping import Array, Bool, Float, Int
+
+from covvfit._variant_beta_binomial.dispersion import (
+    rho_to_log_kappa,
+    select_rho_per_sample,
+)
+
+# Axis-name sentinels for Ruff/Pyflakes handling of jaxtyping string annotations.
+samples = loci = shape = None
+
+
+def make_beta_binomial_shapes(
+    mu: Float[Array, "samples loci"],
+    rho: Float[Array, "*shape"],
+    city: Int[Array, "samples"] | None = None,
+    eps_mu: float = 1e-6,
+) -> tuple[Float[Array, "samples loci"], Float[Array, "samples loci"]]:
+    """Create alpha/beta shape parameters for beta-binomial distribution."""
+    mu = jnp.asarray(mu, dtype=float)
+    if mu.ndim != 2:
+        raise ValueError("mu must have shape (samples, loci).")
+
+    mu_clip = jnp.clip(mu, eps_mu, 1.0 - eps_mu)
+
+    rho_selected = select_rho_per_sample(rho=rho, city=city)
+    log_kappa = rho_to_log_kappa(rho_selected)
+    kappa = jnp.exp(log_kappa)
+
+    if kappa.ndim == 1:
+        kappa = jnp.broadcast_to(kappa, mu.shape)
+    elif kappa.ndim == 2 and kappa.shape != mu.shape:
+        raise ValueError("When city-specific, rho selected shape must match mu shape.")
+
+    alpha = mu_clip * kappa
+    beta = (1.0 - mu_clip) * kappa
+    return alpha, beta
+
+
+def beta_binomial_logpmf(
+    Y: Int[Array, "samples loci"],
+    N: Int[Array, "samples loci"],
+    alpha: Float[Array, "samples loci"],
+    beta: Float[Array, "samples loci"],
+) -> Float[Array, "samples loci"]:
+    """Compute beta-binomial log pmf elementwise."""
+    Y = jnp.asarray(Y, dtype=float)
+    N = jnp.asarray(N, dtype=float)
+    alpha = jnp.asarray(alpha, dtype=float)
+    beta = jnp.asarray(beta, dtype=float)
+
+    if Y.shape != N.shape or Y.shape != alpha.shape or Y.shape != beta.shape:
+        raise ValueError("Y, N, alpha and beta must have the same shape.")
+
+    log_binom = gammaln(N + 1.0) - gammaln(Y + 1.0) - gammaln(N - Y + 1.0)
+    return log_binom + betaln(Y + alpha, N - Y + beta) - betaln(alpha, beta)
+
+
+def masked_beta_binomial_loglik(
+    Y: Int[Array, "samples loci"],
+    N: Int[Array, "samples loci"],
+    alpha: Float[Array, "samples loci"],
+    beta: Float[Array, "samples loci"],
+    obs_mask: Bool[Array, "samples loci"],
+) -> Float[Array, ""]:
+    """Compute total masked beta-binomial log-likelihood."""
+    loglik_matrix = beta_binomial_logpmf(Y=Y, N=N, alpha=alpha, beta=beta)
+    obs_mask = jnp.asarray(obs_mask)
+    if obs_mask.shape != loglik_matrix.shape:
+        raise ValueError("obs_mask must have the same shape as Y and N.")
+    if obs_mask.dtype != jnp.bool_:
+        raise ValueError("obs_mask must have boolean dtype.")
+
+    return jnp.where(obs_mask, loglik_matrix, 0.0).sum()

--- a/src/covvfit/_variant_beta_binomial/mapping.py
+++ b/src/covvfit/_variant_beta_binomial/mapping.py
@@ -1,0 +1,50 @@
+"""Stable variant-to-mutation mapping utilities."""
+
+import jax
+import jax.numpy as jnp
+from jax.scipy.special import logsumexp
+from jaxtyping import Array, Float
+
+
+def make_log_A_mask(
+    A: Float[Array, "variants loci"], dtype: jnp.dtype | None = None
+) -> Float[Array, "variants loci"]:
+    """Build a log-space mask for variant definitions matrix A."""
+    A = jnp.asarray(A)
+    if dtype is None:
+        dtype = A.dtype
+
+    if A.ndim != 2:
+        raise ValueError("A must have shape (variants, loci).")
+
+    neg = jnp.finfo(dtype).min
+    return jnp.where(A == 1, jnp.array(0.0, dtype=dtype), jnp.array(neg, dtype=dtype))
+
+
+def compute_log_mu(
+    log_pi: Float[Array, "samples variants"],
+    A: Float[Array, "variants loci"],
+) -> Float[Array, "samples loci"]:
+    """Compute log expected mutation frequencies in a stable way."""
+    log_pi = jnp.asarray(log_pi)
+    if log_pi.ndim != 2:
+        raise ValueError("log_pi must have shape (samples, variants).")
+
+    A = jnp.asarray(A)
+    if A.ndim != 2:
+        raise ValueError("A must have shape (variants, loci).")
+    if log_pi.shape[1] != A.shape[0]:
+        raise ValueError("log_pi and A shapes are incompatible on variants axis.")
+
+    log_pi = jax.nn.log_softmax(log_pi, axis=1)
+    log_A_mask = make_log_A_mask(A, dtype=log_pi.dtype)
+    tmp = log_pi[:, :, None] + log_A_mask[None, :, :]
+    return logsumexp(tmp, axis=1)
+
+
+def compute_mu(
+    log_pi: Float[Array, "samples variants"],
+    A: Float[Array, "variants loci"],
+) -> Float[Array, "samples loci"]:
+    """Compute expected mutation frequencies."""
+    return jnp.exp(compute_log_mu(log_pi=log_pi, A=A))

--- a/src/covvfit/_variant_beta_binomial/model.py
+++ b/src/covvfit/_variant_beta_binomial/model.py
@@ -1,0 +1,49 @@
+"""Top-level composition for variant beta-binomial model."""
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from covvfit._variant_beta_binomial.data import DispersionParams, ModelData
+from covvfit._variant_beta_binomial.dispersion import (
+    build_eta_rho,
+    transform_eta_to_rho,
+)
+from covvfit._variant_beta_binomial.growth import LinearGrowthParams, compute_log_pi
+from covvfit._variant_beta_binomial.likelihood import (
+    make_beta_binomial_shapes,
+    masked_beta_binomial_loglik,
+)
+from covvfit._variant_beta_binomial.mapping import compute_mu
+
+# Axis-name sentinels for Ruff/Pyflakes handling of jaxtyping string annotations.
+shape = None
+
+
+def model_loglik(
+    growth_params: LinearGrowthParams,
+    dispersion_params: DispersionParams | Float[Array, "*shape"],
+    data: ModelData,
+) -> Float[Array, ""]:
+    """Compute total log-likelihood for observed counts."""
+    log_pi = compute_log_pi(
+        theta=growth_params,
+        city=data.city,
+        time=data.time,
+        X=data.X,
+    )
+    mu = compute_mu(log_pi=log_pi, A=data.A)
+
+    if isinstance(dispersion_params, DispersionParams):
+        eta_rho = build_eta_rho(dispersion_params.eta_rho)
+    else:
+        eta_rho = build_eta_rho(jnp.asarray(dispersion_params, dtype=float))
+
+    rho = transform_eta_to_rho(eta_rho)
+    alpha, beta = make_beta_binomial_shapes(mu=mu, rho=rho, city=data.city)
+    return masked_beta_binomial_loglik(
+        Y=data.Y,
+        N=data.N,
+        alpha=alpha,
+        beta=beta,
+        obs_mask=data.obs_mask,
+    )

--- a/src/covvfit/_variant_beta_binomial/numpyro_model.py
+++ b/src/covvfit/_variant_beta_binomial/numpyro_model.py
@@ -1,0 +1,72 @@
+"""NumPyro models for variant beta-binomial inference."""
+
+import jax.numpy as jnp
+import numpyro
+import numpyro.distributions as dist
+
+from covvfit._variant_beta_binomial.data import DispersionParams, ModelData
+from covvfit._variant_beta_binomial.growth import LinearGrowthParams
+from covvfit._variant_beta_binomial.model import model_loglik
+
+
+def _prepend_reference(x_rel: jnp.ndarray) -> jnp.ndarray:
+    """Add a reference variant fixed at zero for identifiability."""
+    if x_rel.ndim == 1:
+        return jnp.concatenate([jnp.zeros((1,), dtype=x_rel.dtype), x_rel], axis=0)
+    if x_rel.ndim == 2:
+        return jnp.concatenate(
+            [jnp.zeros((x_rel.shape[0], 1), dtype=x_rel.dtype), x_rel], axis=1
+        )
+    raise ValueError("Expected rank-1 or rank-2 array for reference prepend.")
+
+
+def numpyro_model_hierarchical(data: ModelData, n_cities: int) -> None:
+    """Hierarchical Bayesian model for growth + dispersion parameters.
+
+    The first variant is constrained as reference (slope and intercept fixed at 0).
+    """
+    n_variants = data.A.shape[0]
+    n_loci = data.A.shape[1]
+
+    # Shared prior for relative slopes across variants (excluding reference).
+    slope_loc = numpyro.sample("slope_loc", dist.Normal(0.0, 0.3))
+    slope_scale = numpyro.sample("slope_scale", dist.HalfNormal(0.3))
+    slope_raw = numpyro.sample(
+        "slope_raw", dist.Normal(0.0, 1.0).expand([n_variants - 1]).to_event(1)
+    )
+    slopes_rel = slope_loc + slope_scale * slope_raw
+    slopes = _prepend_reference(slopes_rel)
+
+    # City-specific relative intercepts with hierarchical pooling.
+    int_loc = numpyro.sample(
+        "intercept_loc",
+        dist.Normal(0.0, 1.0).expand([n_variants - 1]).to_event(1),
+    )
+    int_scale = numpyro.sample(
+        "intercept_scale",
+        dist.HalfNormal(1.0).expand([n_variants - 1]).to_event(1),
+    )
+    int_raw = numpyro.sample(
+        "intercept_raw",
+        dist.Normal(0.0, 1.0).expand([n_cities, n_variants - 1]).to_event(2),
+    )
+    intercepts_rel = int_loc[None, :] + int_scale[None, :] * int_raw
+    intercepts = _prepend_reference(intercepts_rel)
+
+    # Locus-specific hierarchical prior for dispersion predictor eta_rho.
+    eta_loc = numpyro.sample("eta_loc", dist.Normal(-0.5, 1.0))
+    eta_scale = numpyro.sample("eta_scale", dist.HalfNormal(1.0))
+    eta_raw = numpyro.sample(
+        "eta_raw", dist.Normal(0.0, 1.0).expand([n_loci]).to_event(1)
+    )
+    eta_rho = eta_loc + eta_scale * eta_raw
+
+    growth_params = LinearGrowthParams(intercepts=intercepts, slopes=slopes)
+    dispersion_params = DispersionParams(eta_rho=eta_rho)
+
+    loglik = model_loglik(
+        growth_params=growth_params,
+        dispersion_params=dispersion_params,
+        data=data,
+    )
+    numpyro.factor("obs_loglik", loglik)

--- a/src/covvfit/_variant_beta_binomial/simulate.py
+++ b/src/covvfit/_variant_beta_binomial/simulate.py
@@ -1,0 +1,111 @@
+"""Simulation utilities for variant beta-binomial model."""
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Bool, Float, Int
+
+from covvfit._variant_beta_binomial.data import DispersionParams, ModelData
+from covvfit._variant_beta_binomial.dispersion import transform_eta_to_rho
+from covvfit._variant_beta_binomial.growth import LinearGrowthParams, compute_log_pi
+from covvfit._variant_beta_binomial.likelihood import make_beta_binomial_shapes
+from covvfit._variant_beta_binomial.mapping import compute_mu
+
+# Axis-name sentinels for Ruff/Pyflakes handling of jaxtyping string annotations.
+samples = variants = loci = features = shape = None
+
+
+@dataclass(frozen=True)
+class SimulationResult:
+    """Container for simulated dataset and latent quantities."""
+
+    data: ModelData
+    growth_params: LinearGrowthParams
+    dispersion_params: DispersionParams
+    log_pi: Float[Array, "samples variants"]
+    mu: Float[Array, "samples loci"]
+
+
+def simulate_log_pi(
+    growth_params: LinearGrowthParams,
+    city: Int[Array, "samples"],
+    time: Float[Array, "samples"],
+    X: Float[Array, "samples features"] | None = None,
+) -> Float[Array, "samples variants"]:
+    """Simulate sample-wise log-prevalence scores."""
+    return compute_log_pi(theta=growth_params, city=city, time=time, X=X)
+
+
+def simulate_mu(
+    log_pi: Float[Array, "samples variants"],
+    A: Bool[Array, "variants loci"],
+) -> Float[Array, "samples loci"]:
+    """Simulate expected mutation frequencies."""
+    return compute_mu(log_pi=log_pi, A=A)
+
+
+def sample_beta_binomial_counts(
+    key: jax.Array,
+    N: Int[Array, "samples loci"],
+    alpha: Float[Array, "samples loci"],
+    beta: Float[Array, "samples loci"],
+) -> Int[Array, "samples loci"]:
+    """Sample counts from beta-binomial via beta then binomial draws."""
+    N = jnp.asarray(N)
+    alpha = jnp.asarray(alpha, dtype=float)
+    beta = jnp.asarray(beta, dtype=float)
+
+    key_beta, key_binom = jax.random.split(key)
+    p = jax.random.beta(key_beta, a=alpha, b=beta, shape=alpha.shape)
+    Y = jax.random.binomial(key_binom, n=N.astype(float), p=p, shape=N.shape)
+    return Y.astype(jnp.int32)
+
+
+def simulate_dataset(
+    key: jax.Array,
+    A: Bool[Array, "variants loci"],
+    growth_params: LinearGrowthParams,
+    eta_rho: Float[Array, "*shape"],
+    city: Int[Array, "samples"],
+    time: Float[Array, "samples"],
+    coverage: Int[Array, "samples loci"],
+    X: Float[Array, "samples features"] | None = None,
+    mask_probability: float = 0.1,
+) -> SimulationResult:
+    """Simulate full beta-binomial dataset."""
+    key_counts, key_mask = jax.random.split(key)
+
+    log_pi = simulate_log_pi(growth_params=growth_params, city=city, time=time, X=X)
+    mu = simulate_mu(log_pi=log_pi, A=A)
+
+    rho = transform_eta_to_rho(eta_rho)
+    alpha, beta = make_beta_binomial_shapes(mu=mu, rho=rho, city=city)
+
+    coverage = jnp.asarray(coverage, dtype=jnp.int32)
+    Y = sample_beta_binomial_counts(
+        key=key_counts,
+        N=coverage,
+        alpha=alpha,
+        beta=beta,
+    )
+
+    obs_mask = jax.random.uniform(key_mask, shape=coverage.shape) > mask_probability
+
+    data = ModelData(
+        Y=Y,
+        N=coverage,
+        city=jnp.asarray(city, dtype=jnp.int32),
+        time=jnp.asarray(time, dtype=float),
+        A=jnp.asarray(A, dtype=bool),
+        obs_mask=jnp.asarray(obs_mask, dtype=bool),
+        X=X,
+    )
+
+    return SimulationResult(
+        data=data,
+        growth_params=growth_params,
+        dispersion_params=DispersionParams(eta_rho=jnp.asarray(eta_rho, dtype=float)),
+        log_pi=log_pi,
+        mu=mu,
+    )

--- a/tests/test_installed.py
+++ b/tests/test_installed.py
@@ -3,3 +3,4 @@ import covvfit
 
 def test_imports() -> None:
     assert isinstance(covvfit.VERSION, str)
+    assert covvfit.variant_beta_binomial is not None

--- a/tests/test_variant_beta_binomial_data.py
+++ b/tests/test_variant_beta_binomial_data.py
@@ -1,0 +1,68 @@
+import jax.numpy as jnp
+import pytest
+from covvfit._variant_beta_binomial.data import DispersionParams, ModelData
+
+
+def _valid_data_inputs():
+    Y = jnp.array([[1, 2], [0, 1]], dtype=jnp.int32)
+    N = jnp.array([[3, 3], [2, 2]], dtype=jnp.int32)
+    city = jnp.array([0, 1], dtype=jnp.int32)
+    time = jnp.array([0.0, 1.0], dtype=float)
+    A = jnp.array([[1, 0], [1, 1]], dtype=bool)
+    obs_mask = jnp.array([[True, True], [False, True]], dtype=bool)
+    X = jnp.array([[0.1], [0.2]], dtype=float)
+    return Y, N, city, time, A, obs_mask, X
+
+
+def test_model_data_valid_shapes() -> None:
+    Y, N, city, time, A, obs_mask, X = _valid_data_inputs()
+    data = ModelData(Y=Y, N=N, city=city, time=time, A=A, obs_mask=obs_mask, X=X)
+
+    assert data.Y.shape == (2, 2)
+    assert data.N.shape == (2, 2)
+    assert data.city.shape == (2,)
+    assert data.time.shape == (2,)
+    assert data.A.shape == (2, 2)
+    assert data.obs_mask.shape == (2, 2)
+    assert data.X is not None and data.X.shape == (2, 1)
+
+
+def test_model_data_rejects_non_boolean_mask() -> None:
+    Y, N, city, time, A, _, X = _valid_data_inputs()
+    obs_mask = jnp.array([[1, 1], [0, 1]], dtype=jnp.int32)
+    with pytest.raises(ValueError, match="obs_mask must have boolean dtype"):
+        ModelData(Y=Y, N=N, city=city, time=time, A=A, obs_mask=obs_mask, X=X)
+
+
+def test_model_data_rejects_non_integer_city() -> None:
+    Y, N, _, time, A, obs_mask, X = _valid_data_inputs()
+    city = jnp.array([0.0, 1.0], dtype=float)
+    with pytest.raises(ValueError, match="city must have integer dtype"):
+        ModelData(Y=Y, N=N, city=city, time=time, A=A, obs_mask=obs_mask, X=X)
+
+
+def test_model_data_rejects_non_binary_A() -> None:
+    Y, N, city, time, _, obs_mask, X = _valid_data_inputs()
+    A = jnp.array([[1.0, 0.5], [1.0, 1.0]], dtype=float)
+    with pytest.raises(ValueError, match="A must be binary"):
+        ModelData(Y=Y, N=N, city=city, time=time, A=A, obs_mask=obs_mask, X=X)
+
+
+def test_model_data_rejects_missing_locus_support() -> None:
+    Y, N, city, time, _, obs_mask, X = _valid_data_inputs()
+    A = jnp.array([[1, 0], [0, 0]], dtype=bool)
+    with pytest.raises(ValueError, match="Every locus must be present"):
+        ModelData(Y=Y, N=N, city=city, time=time, A=A, obs_mask=obs_mask, X=X)
+
+
+def test_dispersion_params_shapes() -> None:
+    params_1d = DispersionParams(eta_rho=jnp.zeros((4,)))
+    params_2d = DispersionParams(eta_rho=jnp.zeros((3, 4)))
+
+    assert params_1d.eta_rho.shape == (4,)
+    assert params_2d.eta_rho.shape == (3, 4)
+
+
+def test_dispersion_params_invalid_rank() -> None:
+    with pytest.raises(ValueError, match="eta_rho must have shape"):
+        DispersionParams(eta_rho=jnp.zeros((2, 3, 4)))

--- a/tests/test_variant_beta_binomial_dispersion.py
+++ b/tests/test_variant_beta_binomial_dispersion.py
@@ -1,0 +1,45 @@
+import jax.numpy as jnp
+import numpy.testing as npt
+from covvfit._variant_beta_binomial.dispersion import (
+    rho_to_log_kappa,
+    select_rho_per_sample,
+    transform_eta_to_rho,
+)
+
+
+def test_transform_eta_to_rho_bounds() -> None:
+    eta = jnp.array([-100.0, 0.0, 100.0])
+    rho = transform_eta_to_rho(eta, eps_rho=1e-8)
+
+    assert jnp.all(rho > 1e-8)
+    assert jnp.all(rho < 1.0 - 1e-8)
+
+
+def test_transform_eta_to_rho_shape() -> None:
+    eta = jnp.zeros((3, 4))
+    rho = transform_eta_to_rho(eta)
+    assert rho.shape == eta.shape
+
+
+def test_transform_eta_to_rho_monotonic() -> None:
+    eta = jnp.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+    rho = transform_eta_to_rho(eta)
+
+    assert jnp.all(jnp.diff(rho) > 0)
+
+
+def test_rho_to_log_kappa_finite_extremes() -> None:
+    eta = jnp.array([-100.0, 0.0, 100.0])
+    rho = transform_eta_to_rho(eta)
+    log_kappa = rho_to_log_kappa(rho)
+
+    assert jnp.isfinite(log_kappa).all()
+
+
+def test_select_rho_per_sample_city_specific() -> None:
+    rho = jnp.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])
+    city = jnp.array([2, 0, 1, 2], dtype=jnp.int32)
+
+    selected = select_rho_per_sample(rho=rho, city=city)
+    expected = jnp.array([[0.5, 0.6], [0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])
+    npt.assert_allclose(selected, expected)

--- a/tests/test_variant_beta_binomial_end_to_end.py
+++ b/tests/test_variant_beta_binomial_end_to_end.py
@@ -1,0 +1,85 @@
+import jax
+import jax.numpy as jnp
+from covvfit._variant_beta_binomial.growth import LinearGrowthParams
+from covvfit._variant_beta_binomial.model import model_loglik
+from covvfit._variant_beta_binomial.simulate import simulate_dataset
+
+
+def _build_demo_inputs():
+    key = jax.random.PRNGKey(7)
+    C = 3
+    G = 6
+    N_samples = 60
+
+    city = jnp.repeat(jnp.arange(C, dtype=jnp.int32), N_samples // C)
+    time = jnp.tile(jnp.linspace(0.0, 10.0, N_samples // C), C)
+
+    intercepts = jnp.array(
+        [
+            [0.0, 1.0, -0.4, 0.2],
+            [0.2, 0.6, -0.1, -0.2],
+            [-0.3, 0.8, 0.4, -0.1],
+        ]
+    )
+    slopes = jnp.array([0.05, -0.03, 0.02, 0.01])
+    growth = LinearGrowthParams(intercepts=intercepts, slopes=slopes)
+
+    A = jnp.array(
+        [
+            [1, 0, 1, 0, 1, 0],
+            [0, 1, 1, 0, 0, 1],
+            [1, 1, 0, 1, 0, 0],
+            [0, 0, 1, 1, 1, 1],
+        ],
+        dtype=bool,
+    )
+    coverage = jnp.full((N_samples, G), 80, dtype=jnp.int32)
+    eta_rho = jnp.array([-0.2, 0.0, 0.3, -0.5, 0.1, 0.2])
+
+    result = simulate_dataset(
+        key=key,
+        A=A,
+        growth_params=growth,
+        eta_rho=eta_rho,
+        city=city,
+        time=time,
+        coverage=coverage,
+        mask_probability=0.1,
+    )
+    return result, eta_rho
+
+
+def test_model_loglik_finite_scalar() -> None:
+    result, eta_rho = _build_demo_inputs()
+
+    ll = model_loglik(
+        growth_params=result.growth_params,
+        dispersion_params=eta_rho,
+        data=result.data,
+    )
+
+    assert ll.shape == ()
+    assert jnp.isfinite(ll)
+
+
+def test_parameter_perturbation_changes_likelihood() -> None:
+    result, eta_rho = _build_demo_inputs()
+
+    ll1 = model_loglik(
+        growth_params=result.growth_params,
+        dispersion_params=eta_rho,
+        data=result.data,
+    )
+
+    delta = jnp.zeros_like(result.growth_params.intercepts).at[:, 0].set(0.1)
+    perturbed_growth = LinearGrowthParams(
+        intercepts=result.growth_params.intercepts + delta,
+        slopes=result.growth_params.slopes,
+    )
+    ll2 = model_loglik(
+        growth_params=perturbed_growth,
+        dispersion_params=eta_rho,
+        data=result.data,
+    )
+
+    assert not jnp.isclose(ll1, ll2)

--- a/tests/test_variant_beta_binomial_growth.py
+++ b/tests/test_variant_beta_binomial_growth.py
@@ -1,0 +1,57 @@
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+from covvfit._variant_beta_binomial.growth import LinearGrowthParams, compute_log_pi
+
+
+def test_compute_log_pi_shape() -> None:
+    theta = LinearGrowthParams(
+        intercepts=jnp.array([[0.0, 1.0, -1.0], [0.5, -0.2, 0.3]]),
+        slopes=jnp.array([0.1, -0.2, 0.05]),
+    )
+    city = jnp.array([0, 1, 1, 0], dtype=jnp.int32)
+    time = jnp.array([0.0, 1.0, 2.0, 3.0], dtype=float)
+
+    out = compute_log_pi(theta=theta, city=city, time=time)
+
+    assert out.shape == (4, 3)
+
+
+def test_compute_log_pi_reproducible() -> None:
+    theta = LinearGrowthParams(
+        intercepts=jnp.array([[0.1, 0.2], [0.3, 0.4]]),
+        slopes=jnp.array([0.05, -0.03]),
+    )
+    city = jnp.array([0, 1], dtype=jnp.int32)
+    time = jnp.array([2.0, 5.0], dtype=float)
+
+    out1 = compute_log_pi(theta=theta, city=city, time=time)
+    out2 = compute_log_pi(theta=theta, city=city, time=time)
+    npt.assert_allclose(out1, out2)
+
+
+def test_softmax_rows_sum_to_one() -> None:
+    theta = LinearGrowthParams(
+        intercepts=jnp.array([[0.0, 1.0, -2.0], [1.0, -1.0, 0.5]]),
+        slopes=jnp.array([0.2, 0.1, -0.1]),
+    )
+    city = jnp.array([0, 0, 1], dtype=jnp.int32)
+    time = jnp.array([0.0, 1.0, 2.0], dtype=float)
+
+    log_pi = compute_log_pi(theta=theta, city=city, time=time)
+    probs = jax.nn.softmax(log_pi, axis=-1)
+
+    npt.assert_allclose(probs.sum(axis=-1), jnp.ones((3,)), atol=1e-6)
+
+
+def test_city_changes_output() -> None:
+    theta = LinearGrowthParams(
+        intercepts=jnp.array([[0.0, 0.0], [2.0, -2.0]]),
+        slopes=jnp.array([0.0, 0.0]),
+    )
+    time = jnp.array([1.0, 1.0], dtype=float)
+    city = jnp.array([0, 1], dtype=jnp.int32)
+
+    out = compute_log_pi(theta=theta, city=city, time=time)
+
+    assert not jnp.allclose(out[0], out[1])

--- a/tests/test_variant_beta_binomial_likelihood.py
+++ b/tests/test_variant_beta_binomial_likelihood.py
@@ -1,0 +1,64 @@
+import jax.numpy as jnp
+from covvfit._variant_beta_binomial.likelihood import (
+    beta_binomial_logpmf,
+    make_beta_binomial_shapes,
+    masked_beta_binomial_loglik,
+)
+
+
+def test_make_beta_binomial_shapes_shape() -> None:
+    mu = jnp.array([[0.2, 0.8], [0.3, 0.7]], dtype=float)
+    rho = jnp.array([0.1, 0.2], dtype=float)
+
+    alpha, beta = make_beta_binomial_shapes(mu=mu, rho=rho)
+    assert alpha.shape == mu.shape
+    assert beta.shape == mu.shape
+
+
+def test_make_beta_binomial_shapes_positive() -> None:
+    mu = jnp.array([[0.2, 0.8]], dtype=float)
+    rho = jnp.array([0.1, 0.2], dtype=float)
+
+    alpha, beta = make_beta_binomial_shapes(mu=mu, rho=rho)
+    assert jnp.all(alpha > 0)
+    assert jnp.all(beta > 0)
+
+
+def test_make_beta_binomial_shapes_clipping() -> None:
+    mu = jnp.array([[0.0, 1.0]], dtype=float)
+    rho = jnp.array([0.2, 0.3], dtype=float)
+
+    alpha, beta = make_beta_binomial_shapes(mu=mu, rho=rho)
+    assert jnp.isfinite(alpha).all()
+    assert jnp.isfinite(beta).all()
+    assert jnp.all(alpha > 0)
+    assert jnp.all(beta > 0)
+
+
+def test_beta_binomial_logpmf_finite() -> None:
+    Y = jnp.array([[1, 2], [0, 1]], dtype=jnp.int32)
+    N = jnp.array([[3, 3], [2, 2]], dtype=jnp.int32)
+    alpha = jnp.array([[1.0, 2.0], [1.5, 1.2]], dtype=float)
+    beta = jnp.array([[2.0, 1.0], [1.3, 2.1]], dtype=float)
+
+    out = beta_binomial_logpmf(Y=Y, N=N, alpha=alpha, beta=beta)
+    assert jnp.isfinite(out).all()
+
+
+def test_masked_entries_contribute_zero() -> None:
+    Y = jnp.array([[1, 2]], dtype=jnp.int32)
+    N = jnp.array([[3, 3]], dtype=jnp.int32)
+    alpha = jnp.array([[1.0, 2.0]], dtype=float)
+    beta = jnp.array([[2.0, 1.0]], dtype=float)
+    mask_full = jnp.array([[True, True]])
+    mask_partial = jnp.array([[True, False]])
+
+    full = masked_beta_binomial_loglik(
+        Y=Y, N=N, alpha=alpha, beta=beta, obs_mask=mask_full
+    )
+    part = masked_beta_binomial_loglik(
+        Y=Y, N=N, alpha=alpha, beta=beta, obs_mask=mask_partial
+    )
+
+    cell = beta_binomial_logpmf(Y=Y, N=N, alpha=alpha, beta=beta)[0, 1]
+    assert jnp.isclose(full - part, cell)

--- a/tests/test_variant_beta_binomial_mapping.py
+++ b/tests/test_variant_beta_binomial_mapping.py
@@ -1,0 +1,58 @@
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+from covvfit._variant_beta_binomial.mapping import (
+    compute_log_mu,
+    compute_mu,
+    make_log_A_mask,
+)
+
+
+def test_make_log_A_mask_entries() -> None:
+    A = jnp.array([[1, 0], [0, 1]], dtype=jnp.int32)
+    log_A = make_log_A_mask(A, dtype=jnp.float32)
+
+    assert log_A[0, 0] == 0.0
+    assert log_A[1, 1] == 0.0
+    assert log_A[0, 1] == jnp.finfo(jnp.float32).min
+
+
+def test_compute_log_mu_shape() -> None:
+    log_pi = jnp.array([[0.0, -1.0], [-2.0, 0.0]], dtype=float)
+    A = jnp.array([[1, 0, 1], [0, 1, 1]], dtype=jnp.int32)
+
+    log_mu = compute_log_mu(log_pi=log_pi, A=A)
+    assert log_mu.shape == (2, 3)
+
+
+def test_compute_mu_agrees_with_naive() -> None:
+    log_pi = jnp.array([[0.2, -0.3, 0.1], [0.0, 0.1, -0.4]], dtype=float)
+    A = jnp.array(
+        [
+            [1, 0, 1, 0],
+            [0, 1, 1, 0],
+            [1, 1, 0, 1],
+        ],
+        dtype=float,
+    )
+
+    mu = compute_mu(log_pi=log_pi, A=A)
+    naive = jax.nn.softmax(log_pi, axis=-1) @ A
+    npt.assert_allclose(mu, naive, atol=1e-6)
+
+
+def test_compute_mu_extreme_probabilities_stable() -> None:
+    log_pi = jnp.array([[0.0, -1e9, -1e9]], dtype=float)
+    A = jnp.array([[1, 0], [0, 1], [1, 1]], dtype=jnp.int32)
+
+    mu = compute_mu(log_pi=log_pi, A=A)
+    assert jnp.isfinite(mu).all()
+    npt.assert_allclose(mu[0], jnp.array([1.0, 0.0]), atol=1e-6)
+
+
+def test_invalid_locus_gives_zero_probability() -> None:
+    log_pi = jnp.array([[0.0, 1.0]], dtype=float)
+    A = jnp.array([[1, 0], [0, 0]], dtype=jnp.int32)
+
+    mu = compute_mu(log_pi=log_pi, A=A)
+    assert jnp.isclose(mu[0, 1], 0.0)

--- a/tests/test_variant_beta_binomial_simulation.py
+++ b/tests/test_variant_beta_binomial_simulation.py
@@ -1,0 +1,70 @@
+import jax
+import jax.numpy as jnp
+from covvfit._variant_beta_binomial.growth import LinearGrowthParams
+from covvfit._variant_beta_binomial.simulate import (
+    sample_beta_binomial_counts,
+    simulate_dataset,
+    simulate_log_pi,
+    simulate_mu,
+)
+
+
+def test_sample_beta_binomial_counts_shape() -> None:
+    key = jax.random.PRNGKey(0)
+    N = jnp.full((4, 3), 20, dtype=jnp.int32)
+    alpha = jnp.full((4, 3), 2.0)
+    beta = jnp.full((4, 3), 5.0)
+
+    Y = sample_beta_binomial_counts(key=key, N=N, alpha=alpha, beta=beta)
+    assert Y.shape == N.shape
+    assert jnp.all(Y >= 0)
+    assert jnp.all(Y <= N)
+
+
+def test_simulate_log_pi_and_mu_shapes() -> None:
+    growth = LinearGrowthParams(
+        intercepts=jnp.array([[0.0, 1.0], [0.5, -0.2]]),
+        slopes=jnp.array([0.1, -0.1]),
+    )
+    city = jnp.array([0, 1, 0], dtype=jnp.int32)
+    time = jnp.array([0.0, 1.0, 2.0], dtype=float)
+    A = jnp.array([[1, 0, 1], [0, 1, 1]], dtype=bool)
+
+    log_pi = simulate_log_pi(growth_params=growth, city=city, time=time)
+    mu = simulate_mu(log_pi=log_pi, A=A)
+
+    assert log_pi.shape == (3, 2)
+    assert mu.shape == (3, 3)
+    assert jnp.all(mu >= 0.0)
+    assert jnp.all(mu <= 1.0)
+
+
+def test_simulate_dataset_smoke_with_mask() -> None:
+    key = jax.random.PRNGKey(42)
+    n_samples = 10
+    n_loci = 4
+
+    growth = LinearGrowthParams(
+        intercepts=jnp.array([[0.0, 0.8, -0.3], [0.2, -0.5, 0.3]]),
+        slopes=jnp.array([0.1, -0.05, 0.02]),
+    )
+    city = jnp.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1], dtype=jnp.int32)
+    time = jnp.linspace(0.0, 5.0, n_samples)
+    A = jnp.array([[1, 0, 1, 0], [0, 1, 1, 0], [1, 1, 0, 1]], dtype=bool)
+    coverage = jnp.full((n_samples, n_loci), 50, dtype=jnp.int32)
+    eta_rho = jnp.array([0.0, -0.2, 0.4, -0.1])
+
+    result = simulate_dataset(
+        key=key,
+        A=A,
+        growth_params=growth,
+        eta_rho=eta_rho,
+        city=city,
+        time=time,
+        coverage=coverage,
+        mask_probability=0.15,
+    )
+
+    assert result.data.Y.shape == (n_samples, n_loci)
+    assert result.data.obs_mask.shape == (n_samples, n_loci)
+    assert jnp.any(~result.data.obs_mask)


### PR DESCRIPTION
This PR adds the utilities for doing joint deconvolution and fitness estimation with beta-binomial model based on the count data.

It includes the utilities to fit such models and the examples on simulated data, using HMC or variational inference to infer the selection dynamics parameters.

Current limitations (to potentially be addressed in different PRs):
  - It seems that we have some amount of code duplication right now. The changes are mostly self-contained (in a subpackage), so maybe it's not a big issue.
  - It's currently only on simulated data.
  - Some VI examples there (e.g., the mean field or the IAF) I tried gave rather wrong results, compared with HMC, if too simple family is used or it's not run for long enough.